### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs and scope permissions to job level

### DIFF
--- a/.github/workflows/java-jaxrs-sync-authlete-versions.yml
+++ b/.github/workflows/java-jaxrs-sync-authlete-versions.yml
@@ -5,19 +5,20 @@ on:
     - cron: "17 3 * * *"
   workflow_dispatch: {}
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   sync:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: temurin
           java-version: "8"
@@ -65,7 +66,7 @@ jobs:
 
       - name: Create pull request
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7.0.11
         with:
           commit-message: "chore(java-jaxrs): sync Authlete versions (common v${{ steps.versions.outputs.COMMON_VERSION }}, jaxrs v${{ steps.versions.outputs.JAXRS_VERSION }})"
           title: "chore(java-jaxrs): sync Authlete versions (common v${{ steps.versions.outputs.COMMON_VERSION }}, jaxrs v${{ steps.versions.outputs.JAXRS_VERSION }})"

--- a/.github/workflows/java-jaxrs-tag-on-merge.yml
+++ b/.github/workflows/java-jaxrs-tag-on-merge.yml
@@ -5,16 +5,17 @@ on:
     types: [closed]
     branches: [main]
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   tag:
     if: github.event.pull_request.merged == true
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- java-jaxrs ワークフロー2件で未ピン留めだった GitHub Actions をコミット SHA にピン留め
  - `actions/checkout@v4` → `@11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
  - `actions/setup-java@v4` → `@c1e323688fd81a25caa38c78aa6df2d33d3e20d9` (v4.8.0)
  - `peter-evans/create-pull-request@v7` → `@22a9089034f40e5a961c8808d113e2c98fb63676` (v7.0.11)
- permissions をワークフローレベルから job レベルに移動（最小権限の原則）

## Why
タグハイジャックによるサプライチェーン攻撃を防止するため。他の6ワークフローは既にピン留め済みで、残り2件を同じセキュリティ水準に揃える。

## Test plan
- [ ] java-jaxrs-tag-on-merge: PR マージ時にタグが正しく作成されること
- [ ] java-jaxrs-sync-authlete-versions: 手動実行で正常に動作すること