### PR TITLE
fix(ci): handle missing beta dist-tag in typescript update workflow

### DIFF
--- a/.github/workflows/ruby-update-authlete-sdk.yml
+++ b/.github/workflows/ruby-update-authlete-sdk.yml
@@ -48,6 +48,23 @@ jobs:
           VERSION=$(ruby -e "require 'bundler'; puts Bundler::LockfileParser.new(File.read('Gemfile.lock')).specs.find { |s| s.name == 'authlete_ruby_sdk' }.version")
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Update Gemfile pin
+        if: steps.latest.outputs.version != steps.current.outputs.version
+        working-directory: ruby
+        env:
+          NEW_VERSION: ${{ steps.latest.outputs.version }}
+        run: |
+          ruby <<'RUBY'
+          new_version = ENV.fetch('NEW_VERSION')
+          content = File.read('Gemfile')
+          updated = content.sub(
+            /(gem\s+['"]authlete_ruby_sdk['"]\s*,\s*)['"][^'"]+['"]/,
+            %Q(\\1'#{new_version}')
+          )
+          raise "Failed to update authlete_ruby_sdk pin in Gemfile" if updated == content
+          File.write('Gemfile', updated)
+          RUBY
+
       - name: Update authlete_ruby_sdk
         if: steps.latest.outputs.version != steps.current.outputs.version
         working-directory: ruby

--- a/.github/workflows/ruby-update-authlete-sdk.yml
+++ b/.github/workflows/ruby-update-authlete-sdk.yml
@@ -57,12 +57,10 @@ jobs:
           ruby <<'RUBY'
           new_version = ENV.fetch('NEW_VERSION')
           content = File.read('Gemfile')
-          updated = content.sub(
-            /(gem\s+['"]authlete_ruby_sdk['"]\s*,\s*)['"][^'"]+['"]/,
-            %Q(\\1'#{new_version}')
-          )
-          raise "Failed to update authlete_ruby_sdk pin in Gemfile" if updated == content
-          File.write('Gemfile', updated)
+          pattern = /(gem\s+['"]authlete_ruby_sdk['"]\s*,\s*)['"][^'"]+['"]/
+          raise "authlete_ruby_sdk pin not found in Gemfile" unless content.match?(pattern)
+          updated = content.sub(pattern, %Q(\\1'#{new_version}'))
+          File.write('Gemfile', updated) unless updated == content
           RUBY
 
       - name: Update authlete_ruby_sdk

--- a/.github/workflows/ruby-update-authlete-sdk.yml
+++ b/.github/workflows/ruby-update-authlete-sdk.yml
@@ -31,44 +31,40 @@ jobs:
       - name: Install build dependencies
         run: sudo apt-get install -y --no-install-recommends build-essential
 
+      - name: Get latest version from RubyGems
+        id: latest
+        run: |
+          LATEST=$(curl -sfL https://rubygems.org/api/v1/gems/authlete_ruby_sdk.json | ruby -rjson -e 'puts JSON.parse(STDIN.read)["version"]')
+          if ! echo "$LATEST" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.pre\.[a-zA-Z0-9]+)?$'; then
+            echo "::error::Invalid version format: $LATEST"
+            exit 1
+          fi
+          echo "version=${LATEST}" >> "$GITHUB_OUTPUT"
+
       - name: Get current authlete_ruby_sdk version
-        id: before
+        id: current
         working-directory: ruby
         run: |
           VERSION=$(ruby -e "require 'bundler'; puts Bundler::LockfileParser.new(File.read('Gemfile.lock')).specs.find { |s| s.name == 'authlete_ruby_sdk' }.version")
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Update authlete_ruby_sdk
+        if: steps.latest.outputs.version != steps.current.outputs.version
         working-directory: ruby
         run: bundle update authlete_ruby_sdk
 
-      - name: Detect authlete_ruby_sdk version change
-        id: changes
-        working-directory: ruby
-        run: |
-          NEW_VERSION=$(bundle exec ruby -e "require 'bundler'; puts Bundler.locked_gems.specs.find { |s| s.name == 'authlete_ruby_sdk' }.version")
-          if ! echo "$NEW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.pre\.[a-zA-Z0-9]+)?$'; then
-            echo "::error::Invalid version format: $NEW_VERSION"
-            exit 1
-          fi
-          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-          if [ "$NEW_VERSION" != "${{ steps.before.outputs.version }}" ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Create pull request
-        if: steps.changes.outputs.changed == 'true'
+        if: steps.latest.outputs.version != steps.current.outputs.version
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
         with:
-          commit-message: "chore(ruby): update authlete_ruby_sdk to v${{ steps.changes.outputs.version }}"
-          title: "chore(ruby): update authlete_ruby_sdk to v${{ steps.changes.outputs.version }}"
+          commit-message: "chore(ruby): update authlete_ruby_sdk to v${{ steps.latest.outputs.version }}"
+          title: "chore(ruby): update authlete_ruby_sdk to v${{ steps.latest.outputs.version }}"
           body: |
-            This PR updates `authlete_ruby_sdk` in `ruby/Gemfile.lock` to the latest available version.
+            This PR updates `authlete_ruby_sdk` in `ruby/Gemfile.lock` to the latest version from RubyGems.
 
             - Package: [authlete_ruby_sdk](https://rubygems.org/gems/authlete_ruby_sdk)
-            - New version: `${{ steps.changes.outputs.version }}`
+            - Previous version: `${{ steps.current.outputs.version }}`
+            - New version: `${{ steps.latest.outputs.version }}`
           branch: "chore/ruby-update-authlete-ruby-sdk"
           delete-branch: true
           add-paths: |

--- a/.github/workflows/typescript-update-authlete-sdk.yml
+++ b/.github/workflows/typescript-update-authlete-sdk.yml
@@ -30,11 +30,18 @@ jobs:
         id: latest
         working-directory: typescript
         run: |
-          LATEST=$(npm view @authlete/typescript-sdk dist-tags.beta 2>/dev/null || npm view @authlete/typescript-sdk versions --json | node -e "
-            const v = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
-            const betas = v.filter(x => x.includes('beta'));
-            console.log(betas.at(-1));
-          ")
+          LATEST=$(npm view @authlete/typescript-sdk dist-tags.beta 2>/dev/null || true)
+          if [ -z "$LATEST" ]; then
+            LATEST=$(npm view @authlete/typescript-sdk versions --json | node -e "
+              const v = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+              const betas = v.filter(x => x.includes('beta'));
+              if (betas.length === 0) {
+                process.stderr.write('No beta version found on registry\n');
+                process.exit(1);
+              }
+              console.log(betas[betas.length - 1]);
+            ")
+          fi
           if ! echo "$LATEST" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
             echo "::error::Invalid version format: $LATEST"
             exit 1

--- a/.github/workflows/typescript-update-authlete-sdk.yml
+++ b/.github/workflows/typescript-update-authlete-sdk.yml
@@ -26,22 +26,11 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Get latest beta version
+      - name: Get latest version
         id: latest
         working-directory: typescript
         run: |
-          LATEST=$(npm view @authlete/typescript-sdk dist-tags.beta 2>/dev/null || true)
-          if [ -z "$LATEST" ]; then
-            LATEST=$(npm view @authlete/typescript-sdk versions --json | node -e "
-              const v = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
-              const betas = v.filter(x => x.includes('beta'));
-              if (betas.length === 0) {
-                process.stderr.write('No beta version found on registry\n');
-                process.exit(1);
-              }
-              console.log(betas[betas.length - 1]);
-            ")
-          fi
+          LATEST=$(npm view @authlete/typescript-sdk dist-tags.latest)
           if ! echo "$LATEST" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
             echo "::error::Invalid version format: $LATEST"
             exit 1
@@ -72,7 +61,7 @@ jobs:
           commit-message: "chore(typescript): update @authlete/typescript-sdk to v${{ steps.latest.outputs.version }}"
           title: "chore(typescript): update @authlete/typescript-sdk to v${{ steps.latest.outputs.version }}"
           body: |
-            This PR updates `@authlete/typescript-sdk` in `typescript/package.json` and `package-lock.json` to the latest beta version.
+            This PR updates `@authlete/typescript-sdk` in `typescript/package.json` and `package-lock.json` to the latest version.
 
             - Package: [@authlete/typescript-sdk](https://www.npmjs.com/package/@authlete/typescript-sdk)
             - Previous version: `${{ steps.current.outputs.version }}`

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 
 ruby '>= 3.4'
 
-gem 'authlete_ruby_sdk'
+gem 'authlete_ruby_sdk', '0.0.5.pre.beta'

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 
 ruby '>= 3.4'
 
-gem 'authlete_ruby_sdk', '0.0.5.pre.beta'
+gem 'authlete_ruby_sdk'


### PR DESCRIPTION
npm view ... dist-tags.beta returns empty string with exit code 0 when
the beta dist-tag is absent, so the || fallback never fired and LATEST
was empty, causing the version regex check to fail.

The beta dist-tag was removed from @authlete/typescript-sdk after 1.0.0
was published. Explicitly branch on empty output so the versions-list
fallback runs, and fail loudly if no beta version exists either.