### PR TITLE
test: add authorization code flow smoke tests and devcontainer CI

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -11,6 +11,17 @@ AUTHLETE_SERVICE_APISECRET=
 AUTHLETE_SERVICE_ACCESSTOKEN=
 AUTHLETE_API_VERSION=
 
+# Optional: version-specific credentials for the Java smoke tests.
+# When set, the Java authorization code flow smoke test runs against both
+# V2 and V3 in a single run. When not set, the test falls back to the
+# AUTHLETE_* variables above (selected by AUTHLETE_API_VERSION).
+AUTHLETE_V2_BASE_URL=
+AUTHLETE_V2_SERVICE_APIKEY=
+AUTHLETE_V2_SERVICE_APISECRET=
+AUTHLETE_V3_BASE_URL=
+AUTHLETE_V3_SERVICE_APIKEY=
+AUTHLETE_V3_SERVICE_ACCESSTOKEN=
+
 # Optional service owner credentials
 AUTHLETE_SERVICEOWNER_APIKEY=
 AUTHLETE_SERVICEOWNER_APISECRET=

--- a/.github/workflows/devcontainer-smoke-test.yml
+++ b/.github/workflows/devcontainer-smoke-test.yml
@@ -34,36 +34,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Java SDKs support both Authlete V2 and V3; the JUnit test reads
-          # AUTHLETE_V2_* / AUTHLETE_V3_* and covers both in a single run.
+          # Every test reads the version-specific AUTHLETE_V2_* / AUTHLETE_V3_*
+          # variables for the API versions its SDK supports (Java covers both
+          # in a single run; the others are V2- or V3-only).
           - lang: java
-            api: both
             test_cmd: mvn -B test
           - lang: java-jakarta
-            api: both
             test_cmd: mvn -B test
           - lang: java-jaxrs
-            api: both
             test_cmd: mvn -B test
-          # openapi-for-go supports V2 only.
-          - lang: go
-            api: v2
+          - lang: go # V2 only
             test_cmd: go test -v ./...
-          # authlete_ruby_sdk supports V3 only.
-          - lang: ruby
-            api: v3
+          - lang: ruby # V3 only
             test_cmd: bundle install && bundle exec ruby test/authorization_code_flow_test.rb
-          # authlete gem supports V2 only.
-          - lang: ruby-v2
-            api: v2
+          - lang: ruby-v2 # V2 only
             test_cmd: bundle install && bundle exec ruby test/authorization_code_flow_test.rb
-          # @authlete/typescript-sdk supports V3 only.
-          - lang: typescript
-            api: v3
+          - lang: typescript # V3 only
             test_cmd: npm install && npm test
-          # authlete/authlete (PHP) supports V2 only.
-          - lang: php
-            api: v2
+          - lang: php # V2 only
             test_cmd: composer install --no-interaction --no-progress && composer test
 
     steps:
@@ -72,7 +60,6 @@ jobs:
 
       - name: Create .env.local from secrets
         env:
-          API: ${{ matrix.api }}
           V2_BASE_URL: ${{ secrets.AUTHLETE_V2_BASE_URL }}
           V2_APIKEY: ${{ secrets.AUTHLETE_V2_SERVICE_APIKEY }}
           V2_APISECRET: ${{ secrets.AUTHLETE_V2_SERVICE_APISECRET }}
@@ -80,33 +67,14 @@ jobs:
           V3_APIKEY: ${{ secrets.AUTHLETE_V3_SERVICE_APIKEY }}
           V3_ACCESSTOKEN: ${{ secrets.AUTHLETE_V3_SERVICE_ACCESSTOKEN }}
         run: |
-          case "${API}" in
-            v2)
-              {
-                echo "AUTHLETE_BASE_URL=${V2_BASE_URL}"
-                echo "AUTHLETE_SERVICE_APIKEY=${V2_APIKEY}"
-                echo "AUTHLETE_SERVICE_APISECRET=${V2_APISECRET}"
-              } > .env.local
-              ;;
-            v3)
-              {
-                echo "AUTHLETE_BASE_URL=${V3_BASE_URL}"
-                echo "AUTHLETE_SERVICE_APIKEY=${V3_APIKEY}"
-                echo "AUTHLETE_SERVICE_ACCESSTOKEN=${V3_ACCESSTOKEN}"
-                echo "AUTHLETE_API_VERSION=3"
-              } > .env.local
-              ;;
-            both)
-              {
-                echo "AUTHLETE_V2_BASE_URL=${V2_BASE_URL}"
-                echo "AUTHLETE_V2_SERVICE_APIKEY=${V2_APIKEY}"
-                echo "AUTHLETE_V2_SERVICE_APISECRET=${V2_APISECRET}"
-                echo "AUTHLETE_V3_BASE_URL=${V3_BASE_URL}"
-                echo "AUTHLETE_V3_SERVICE_APIKEY=${V3_APIKEY}"
-                echo "AUTHLETE_V3_SERVICE_ACCESSTOKEN=${V3_ACCESSTOKEN}"
-              } > .env.local
-              ;;
-          esac
+          {
+            echo "AUTHLETE_V2_BASE_URL=${V2_BASE_URL}"
+            echo "AUTHLETE_V2_SERVICE_APIKEY=${V2_APIKEY}"
+            echo "AUTHLETE_V2_SERVICE_APISECRET=${V2_APISECRET}"
+            echo "AUTHLETE_V3_BASE_URL=${V3_BASE_URL}"
+            echo "AUTHLETE_V3_SERVICE_APIKEY=${V3_APIKEY}"
+            echo "AUTHLETE_V3_SERVICE_ACCESSTOKEN=${V3_ACCESSTOKEN}"
+          } > .env.local
 
       - name: Build devcontainer and run smoke test
         uses: devcontainers/ci@v0.3

--- a/.github/workflows/devcontainer-smoke-test.yml
+++ b/.github/workflows/devcontainer-smoke-test.yml
@@ -1,0 +1,116 @@
+# Builds each language's Dev Container (the same path GitHub Codespaces uses)
+# and runs an OAuth 2.0 authorization code flow smoke test inside it.
+#
+# Required repository secrets (tests are skipped gracefully when missing,
+# so the workflow still verifies that the containers build and compile):
+#   AUTHLETE_V2_BASE_URL / AUTHLETE_V2_SERVICE_APIKEY / AUTHLETE_V2_SERVICE_APISECRET
+#   AUTHLETE_V3_BASE_URL / AUTHLETE_V3_SERVICE_APIKEY / AUTHLETE_V3_SERVICE_ACCESSTOKEN
+name: Devcontainer smoke test
+
+on:
+  pull_request:
+    paths:
+      - '.devcontainer/**'
+      - '.github/workflows/devcontainer-smoke-test.yml'
+      - 'java/**'
+      - 'java-jakarta/**'
+      - 'java-jaxrs/**'
+      - 'go/**'
+      - 'ruby/**'
+      - 'ruby-v2/**'
+      - 'typescript/**'
+      - 'php/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Java SDKs support both Authlete V2 and V3; the JUnit test reads
+          # AUTHLETE_V2_* / AUTHLETE_V3_* and covers both in a single run.
+          - lang: java
+            api: both
+            test_cmd: mvn -B test
+          - lang: java-jakarta
+            api: both
+            test_cmd: mvn -B test
+          - lang: java-jaxrs
+            api: both
+            test_cmd: mvn -B test
+          # openapi-for-go supports V2 only.
+          - lang: go
+            api: v2
+            test_cmd: go test -v ./...
+          # authlete_ruby_sdk supports V3 only.
+          - lang: ruby
+            api: v3
+            test_cmd: bundle install && bundle exec ruby test/authorization_code_flow_test.rb
+          # authlete gem supports V2 only.
+          - lang: ruby-v2
+            api: v2
+            test_cmd: bundle install && bundle exec ruby test/authorization_code_flow_test.rb
+          # @authlete/typescript-sdk supports V3 only.
+          - lang: typescript
+            api: v3
+            test_cmd: npm install && npm test
+          # authlete/authlete (PHP) supports V2 only.
+          - lang: php
+            api: v2
+            test_cmd: composer install --no-interaction --no-progress && composer test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create .env.local from secrets
+        env:
+          API: ${{ matrix.api }}
+          V2_BASE_URL: ${{ secrets.AUTHLETE_V2_BASE_URL }}
+          V2_APIKEY: ${{ secrets.AUTHLETE_V2_SERVICE_APIKEY }}
+          V2_APISECRET: ${{ secrets.AUTHLETE_V2_SERVICE_APISECRET }}
+          V3_BASE_URL: ${{ secrets.AUTHLETE_V3_BASE_URL }}
+          V3_APIKEY: ${{ secrets.AUTHLETE_V3_SERVICE_APIKEY }}
+          V3_ACCESSTOKEN: ${{ secrets.AUTHLETE_V3_SERVICE_ACCESSTOKEN }}
+        run: |
+          case "${API}" in
+            v2)
+              {
+                echo "AUTHLETE_BASE_URL=${V2_BASE_URL}"
+                echo "AUTHLETE_SERVICE_APIKEY=${V2_APIKEY}"
+                echo "AUTHLETE_SERVICE_APISECRET=${V2_APISECRET}"
+              } > .env.local
+              ;;
+            v3)
+              {
+                echo "AUTHLETE_BASE_URL=${V3_BASE_URL}"
+                echo "AUTHLETE_SERVICE_APIKEY=${V3_APIKEY}"
+                echo "AUTHLETE_SERVICE_ACCESSTOKEN=${V3_ACCESSTOKEN}"
+                echo "AUTHLETE_API_VERSION=3"
+              } > .env.local
+              ;;
+            both)
+              {
+                echo "AUTHLETE_V2_BASE_URL=${V2_BASE_URL}"
+                echo "AUTHLETE_V2_SERVICE_APIKEY=${V2_APIKEY}"
+                echo "AUTHLETE_V2_SERVICE_APISECRET=${V2_APISECRET}"
+                echo "AUTHLETE_V3_BASE_URL=${V3_BASE_URL}"
+                echo "AUTHLETE_V3_SERVICE_APIKEY=${V3_APIKEY}"
+                echo "AUTHLETE_V3_SERVICE_ACCESSTOKEN=${V3_ACCESSTOKEN}"
+              } > .env.local
+              ;;
+          esac
+
+      - name: Build devcontainer and run smoke test
+        uses: devcontainers/ci@v0.3
+        with:
+          configFile: .devcontainer/${{ matrix.lang }}/devcontainer.json
+          push: never
+          runCmd: ${{ matrix.test_cmd }}

--- a/README.ja.md
+++ b/README.ja.md
@@ -136,6 +136,45 @@ SDKでは以下の環境変数が使用されます：
 - AUTHLETE_SERVICE_ACCESSTOKEN
 - AUTHLETE_API_VERSION
 
+## スモークテスト
+
+各言語のディレクトリには、実際の Authlete サーバーに対して OAuth 2.0
+認可コードフローを一通り実行するスモークテストが含まれています：
+
+1. クライアント管理 API でテスト用クライアントを作成
+2. `/auth/authorization`（`response_type=code`）
+3. `/auth/authorization/issue`
+4. `/auth/token`（認可コードをアクセストークンに交換）
+5. `/auth/introspection`（発行されたアクセストークンを検証）
+6. テスト用クライアントを削除（失敗時も必ず実行）
+
+テストはサンプルアプリケーションと同じ `AUTHLETE_*` 環境変数を参照し、
+資格情報が設定されていない場合はスキップされるため、チェックアウト直後でも
+失敗しません。
+
+| 言語 | コマンド（Dev Container 内で実行） | API バージョン |
+|------|-------------------------------------|----------------|
+| Java / Java Jakarta / Java JAX-RS | `mvn test` | V2 と V3 |
+| Go | `go test ./...` | V2 のみ |
+| Ruby (v3) | `bundle exec ruby test/authorization_code_flow_test.rb` | V3 のみ |
+| Ruby (v2) | `bundle exec ruby test/authorization_code_flow_test.rb` | V2 のみ |
+| TypeScript | `npm test` | V3 のみ |
+| PHP | `composer test` | V2 のみ |
+
+Java のスモークテストは 1 回の実行で V2 / V3 の両方をテストできます。
+`.env.local` にバージョン別の変数（`AUTHLETE_V2_BASE_URL`、
+`AUTHLETE_V2_SERVICE_APIKEY`、`AUTHLETE_V2_SERVICE_APISECRET`、
+`AUTHLETE_V3_BASE_URL`、`AUTHLETE_V3_SERVICE_APIKEY`、
+`AUTHLETE_V3_SERVICE_ACCESSTOKEN`）を設定してください。未設定の場合は
+既存の `AUTHLETE_*` 変数にフォールバックし、該当する API バージョンのみ
+実行します。資格情報が無い側のフローはスキップされます。
+
+GitHub Actions ワークフロー `Devcontainer smoke test`
+（`.github/workflows/devcontainer-smoke-test.yml`）は、言語ディレクトリに
+変更がある Pull Request ごとに各言語の Dev Container（GitHub Codespaces と
+同じ構成）をビルドし、コンテナ内でこれらのテストを実行します。これにより
+SDK 自動更新 PR も自動的に検証されます。
+
 ## 環境のカスタマイズ
 
 各言語環境は、対応するファイルを変更することでカスタマイズできます：

--- a/README.ja.md
+++ b/README.ja.md
@@ -174,6 +174,10 @@ SDKでは以下の環境変数が使用されます：
 のアクセス権限が必要です。権限が無い場合、クライアント作成が `A457101`
 で失敗します。
 
+注意: PHP のテストは、サービスが `authlete/authlete` 1.x のパースできない
+grant type（`TOKEN_EXCHANGE`、`JWT_BEARER` など）をサポートしている場合、
+API レスポンスを解釈できないため SKIP を報告します。
+
 GitHub Actions ワークフロー `Devcontainer smoke test`
 （`.github/workflows/devcontainer-smoke-test.yml`）は、言語ディレクトリに
 変更がある Pull Request ごとに各言語の Dev Container（GitHub Codespaces と

--- a/README.ja.md
+++ b/README.ja.md
@@ -161,13 +161,18 @@ SDKでは以下の環境変数が使用されます：
 | TypeScript | `npm test` | V3 のみ |
 | PHP | `composer test` | V2 のみ |
 
-Java のスモークテストは 1 回の実行で V2 / V3 の両方をテストできます。
-`.env.local` にバージョン別の変数（`AUTHLETE_V2_BASE_URL`、
-`AUTHLETE_V2_SERVICE_APIKEY`、`AUTHLETE_V2_SERVICE_APISECRET`、
-`AUTHLETE_V3_BASE_URL`、`AUTHLETE_V3_SERVICE_APIKEY`、
-`AUTHLETE_V3_SERVICE_ACCESSTOKEN`）を設定してください。未設定の場合は
-既存の `AUTHLETE_*` 変数にフォールバックし、該当する API バージョンのみ
-実行します。資格情報が無い側のフローはスキップされます。
+すべてのスモークテストは、SDK が対応する API バージョンのバージョン別変数
+（`AUTHLETE_V2_BASE_URL`、`AUTHLETE_V2_SERVICE_APIKEY`、
+`AUTHLETE_V2_SERVICE_APISECRET`、`AUTHLETE_V3_BASE_URL`、
+`AUTHLETE_V3_SERVICE_APIKEY`、`AUTHLETE_V3_SERVICE_ACCESSTOKEN`）を優先して
+参照するため、1 つの `.env.local` で全言語をまとめて検証できます（Java は
+1 回の実行で V2 / V3 の両方をテストします）。バージョン別変数が未設定の
+場合は、API バージョンが一致するときに限り既存の `AUTHLETE_*` 変数に
+フォールバックします。資格情報が無いフローはスキップされます。
+
+注意: V3 のサービスアクセストークンには `CREATE_CLIENT` / `DELETE_CLIENT`
+のアクセス権限が必要です。権限が無い場合、クライアント作成が `A457101`
+で失敗します。
 
 GitHub Actions ワークフロー `Devcontainer smoke test`
 （`.github/workflows/devcontainer-smoke-test.yml`）は、言語ディレクトリに

--- a/README.ja.md
+++ b/README.ja.md
@@ -152,6 +152,11 @@ SDKでは以下の環境変数が使用されます：
 資格情報が設定されていない場合はスキップされるため、チェックアウト直後でも
 失敗しません。
 
+一時的なエラー（HTTP 429 および 5xx）は
+[レートリミットのベストプラクティス](https://www.authlete.com/ja/kb/deployment/performance/ratelimit-best-practices/)
+に従い、指数バックオフ + ジッターでリトライします（SDK がレスポンスヘッダーを
+公開している場合は `Ratelimit-Reset` ヘッダーを優先します）。
+
 | 言語 | コマンド（Dev Container 内で実行） | API バージョン |
 |------|-------------------------------------|----------------|
 | Java / Java Jakarta / Java JAX-RS | `mvn test` | V2 と V3 |

--- a/README.md
+++ b/README.md
@@ -136,6 +136,45 @@ For SDKs that do not have such functionality, the client is instantiated by expl
 - AUTHLETE_SERVICE_ACCESSTOKEN
 - AUTHLETE_API_VERSION
 
+## Smoke Tests
+
+Each language directory contains a smoke test that runs a minimal OAuth 2.0
+authorization code flow against a real Authlete server:
+
+1. Create a disposable client via the client management API
+2. `/auth/authorization` (`response_type=code`)
+3. `/auth/authorization/issue`
+4. `/auth/token` (exchange the authorization code for an access token)
+5. `/auth/introspection` (verify the issued access token)
+6. Delete the disposable client (always, even on failure)
+
+The tests read the same `AUTHLETE_*` environment variables as the sample
+applications and are skipped when credentials are not configured, so they
+never fail on a fresh checkout.
+
+| Language | Command (inside the Dev Container) | API version |
+|----------|-------------------------------------|-------------|
+| Java / Java Jakarta / Java JAX-RS | `mvn test` | V2 and V3 |
+| Go | `go test ./...` | V2 only |
+| Ruby (v3) | `bundle exec ruby test/authorization_code_flow_test.rb` | V3 only |
+| Ruby (v2) | `bundle exec ruby test/authorization_code_flow_test.rb` | V2 only |
+| TypeScript | `npm test` | V3 only |
+| PHP | `composer test` | V2 only |
+
+The Java smoke tests can cover both V2 and V3 in a single run. Set the
+version-specific variables (`AUTHLETE_V2_BASE_URL`, `AUTHLETE_V2_SERVICE_APIKEY`,
+`AUTHLETE_V2_SERVICE_APISECRET`, `AUTHLETE_V3_BASE_URL`,
+`AUTHLETE_V3_SERVICE_APIKEY`, `AUTHLETE_V3_SERVICE_ACCESSTOKEN`) in
+`.env.local`. When they are not set, the Java tests fall back to the plain
+`AUTHLETE_*` variables and run only the matching API version. A flow whose
+credentials are missing is skipped.
+
+The `Devcontainer smoke test` GitHub Actions workflow
+(`.github/workflows/devcontainer-smoke-test.yml`) builds every language's
+Dev Container — the same configuration GitHub Codespaces uses — and runs
+these tests inside it on every pull request that touches a language
+directory, so SDK update PRs are verified automatically.
+
 ## Customizing the Environment
 
 Each language environment can be customized by modifying the corresponding files:

--- a/README.md
+++ b/README.md
@@ -161,13 +161,18 @@ never fail on a fresh checkout.
 | TypeScript | `npm test` | V3 only |
 | PHP | `composer test` | V2 only |
 
-The Java smoke tests can cover both V2 and V3 in a single run. Set the
-version-specific variables (`AUTHLETE_V2_BASE_URL`, `AUTHLETE_V2_SERVICE_APIKEY`,
+Every smoke test prefers the version-specific variables
+(`AUTHLETE_V2_BASE_URL`, `AUTHLETE_V2_SERVICE_APIKEY`,
 `AUTHLETE_V2_SERVICE_APISECRET`, `AUTHLETE_V3_BASE_URL`,
-`AUTHLETE_V3_SERVICE_APIKEY`, `AUTHLETE_V3_SERVICE_ACCESSTOKEN`) in
-`.env.local`. When they are not set, the Java tests fall back to the plain
-`AUTHLETE_*` variables and run only the matching API version. A flow whose
+`AUTHLETE_V3_SERVICE_APIKEY`, `AUTHLETE_V3_SERVICE_ACCESSTOKEN`) for the API
+version(s) its SDK supports, so a single `.env.local` can drive all languages
+at once — the Java tests cover both V2 and V3 in one run. When the
+version-specific variables are not set, each test falls back to the plain
+`AUTHLETE_*` variables if they match its API version. A flow whose
 credentials are missing is skipped.
+
+Note: the V3 service access token must have `CREATE_CLIENT` / `DELETE_CLIENT`
+access rights; otherwise client creation fails with `A457101`.
 
 The `Devcontainer smoke test` GitHub Actions workflow
 (`.github/workflows/devcontainer-smoke-test.yml`) builds every language's

--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ credentials are missing is skipped.
 Note: the V3 service access token must have `CREATE_CLIENT` / `DELETE_CLIENT`
 access rights; otherwise client creation fails with `A457101`.
 
+Note: the PHP test reports SKIP when the service supports grant types that
+`authlete/authlete` 1.x cannot parse (such as `TOKEN_EXCHANGE` or
+`JWT_BEARER`), because API responses containing them are unparseable with
+that SDK.
+
 The `Devcontainer smoke test` GitHub Actions workflow
 (`.github/workflows/devcontainer-smoke-test.yml`) builds every language's
 Dev Container — the same configuration GitHub Codespaces uses — and runs

--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ The tests read the same `AUTHLETE_*` environment variables as the sample
 applications and are skipped when credentials are not configured, so they
 never fail on a fresh checkout.
 
+Transient errors (HTTP 429 and 5xx) are retried with exponential backoff
+and jitter, honoring the `Ratelimit-Reset` header where the SDK exposes
+response headers, following the
+[rate limit best practices](https://www.authlete.com/kb/deployment/performance/ratelimit-best-practices/).
+
 | Language | Command (inside the Dev Container) | API version |
 |----------|-------------------------------------|-------------|
 | Java / Java Jakarta / Java JAX-RS | `mvn test` | V2 and V3 |

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -30,4 +30,5 @@ COPY --chown=${USERNAME}:${USER_GID} go.mod go.sum ./
 RUN go mod download
 
 # install dlv for debugging
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
+# (pinned: delve >= 1.27 requires go >= 1.25, newer than the base image toolchain)
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.25.2

--- a/go/authorization_code_flow_test.go
+++ b/go/authorization_code_flow_test.go
@@ -4,10 +4,14 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"math/big"
+	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	authlete "github.com/authlete/openapi-for-go"
 )
@@ -17,7 +21,53 @@ const (
 	testSubject     = "sdk-playground-user"
 	// The V2 /client/create API requires a developer identifier.
 	testDeveloper = "sdk-playground-developer"
+	// Transient errors (429 and 5xx) are retried with exponential backoff.
+	maxRetries = 3
 )
+
+// callWithRetry executes an Authlete API call, retrying transient errors
+// (429 and 5xx) following
+// https://www.authlete.com/kb/deployment/performance/ratelimit-best-practices/:
+// honor the Ratelimit-Reset header when present, otherwise use exponential
+// backoff (500 ms, 1 s, 2 s) with a small random jitter.
+func callWithRetry[T any](t *testing.T, label string, call func() (T, *http.Response, error)) (T, *http.Response, error) {
+	t.Helper()
+
+	for attempt := 0; ; attempt++ {
+		result, httpResp, err := call()
+		if err == nil || httpResp == nil || attempt >= maxRetries || !isRetryableStatus(httpResp.StatusCode) {
+			return result, httpResp, err
+		}
+
+		delay := retryDelay(t, attempt, httpResp)
+		t.Logf("%s failed with HTTP %d; retrying in %v (attempt %d/%d)",
+			label, httpResp.StatusCode, delay, attempt+1, maxRetries)
+		time.Sleep(delay)
+	}
+}
+
+func isRetryableStatus(statusCode int) bool {
+	return statusCode == 429 || statusCode >= 500
+}
+
+func retryDelay(t *testing.T, attempt int, httpResp *http.Response) time.Duration {
+	t.Helper()
+
+	if value := strings.TrimSpace(httpResp.Header.Get("Ratelimit-Reset")); value != "" {
+		if seconds, err := strconv.Atoi(value); err == nil && seconds > 0 {
+			if seconds > 30 {
+				seconds = 30
+			}
+			return time.Duration(seconds) * time.Second
+		}
+	}
+
+	jitter, err := rand.Int(rand.Reader, big.NewInt(250))
+	if err != nil {
+		t.Fatalf("failed to generate retry jitter: %v", err)
+	}
+	return time.Duration(500<<attempt)*time.Millisecond + time.Duration(jitter.Int64())*time.Millisecond
+}
 
 // TestAuthorizationCodeFlow runs a minimal OAuth 2.0 authorization code flow
 // against the Authlete V2 API to verify that the SDK works in this environment:
@@ -62,7 +112,9 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 	newClient.SetResponseTypes([]authlete.ResponseType{authlete.RESPONSETYPE_CODE})
 	newClient.SetRedirectUris([]string{testRedirectURI})
 
-	created, _, err := apiClient.ClientManagementApi.ClientCreateApi(ctx).Client(*newClient).Execute()
+	created, _, err := callWithRetry(t, "/client/create", func() (*authlete.Client, *http.Response, error) {
+		return apiClient.ClientManagementApi.ClientCreateApi(ctx).Client(*newClient).Execute()
+	})
 	if err != nil {
 		t.Fatalf("/client/create failed: %v", err)
 	}
@@ -71,7 +123,10 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 
 	// Always clean up the client, even when the flow fails halfway.
 	defer func() {
-		_, err := apiClient.ClientManagementApi.ClientDeleteApi(ctx, fmt.Sprintf("%d", clientID)).Execute()
+		_, _, err := callWithRetry(t, "/client/delete", func() (struct{}, *http.Response, error) {
+			httpResp, err := apiClient.ClientManagementApi.ClientDeleteApi(ctx, fmt.Sprintf("%d", clientID)).Execute()
+			return struct{}{}, httpResp, err
+		})
 		if err != nil {
 			t.Errorf("/client/delete failed for client %d: %v", clientID, err)
 			return
@@ -88,7 +143,9 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 	authzParams.Set("state", state)
 
 	authzReq := authlete.NewAuthorizationRequest(authzParams.Encode())
-	authzResp, _, err := apiClient.AuthorizationEndpointApi.AuthAuthorizationApi(ctx).AuthorizationRequest(*authzReq).Execute()
+	authzResp, _, err := callWithRetry(t, "/auth/authorization", func() (*authlete.AuthorizationResponse, *http.Response, error) {
+		return apiClient.AuthorizationEndpointApi.AuthAuthorizationApi(ctx).AuthorizationRequest(*authzReq).Execute()
+	})
 	if err != nil {
 		t.Fatalf("/auth/authorization failed: %v", err)
 	}
@@ -103,7 +160,9 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 
 	// Step 3: /auth/authorization/issue
 	issueReq := authlete.NewAuthorizationIssueRequest(ticket, testSubject)
-	issueResp, _, err := apiClient.AuthorizationEndpointApi.AuthAuthorizationIssueApi(ctx).AuthorizationIssueRequest(*issueReq).Execute()
+	issueResp, _, err := callWithRetry(t, "/auth/authorization/issue", func() (*authlete.AuthorizationIssueResponse, *http.Response, error) {
+		return apiClient.AuthorizationEndpointApi.AuthAuthorizationIssueApi(ctx).AuthorizationIssueRequest(*issueReq).Execute()
+	})
 	if err != nil {
 		t.Fatalf("/auth/authorization/issue failed: %v", err)
 	}
@@ -136,7 +195,9 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 	tokenReq := authlete.NewTokenRequest(tokenParams.Encode())
 	tokenReq.SetClientId(fmt.Sprintf("%d", clientID))
 	tokenReq.SetClientSecret(created.GetClientSecret())
-	tokenResp, _, err := apiClient.TokenEndpointApi.AuthTokenApi(ctx).TokenRequest(*tokenReq).Execute()
+	tokenResp, _, err := callWithRetry(t, "/auth/token", func() (*authlete.TokenResponse, *http.Response, error) {
+		return apiClient.TokenEndpointApi.AuthTokenApi(ctx).TokenRequest(*tokenReq).Execute()
+	})
 	if err != nil {
 		t.Fatalf("/auth/token failed: %v", err)
 	}
@@ -151,7 +212,9 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 
 	// Step 5: /auth/introspection
 	introReq := authlete.NewIntrospectionRequest(accessToken)
-	introResp, _, err := apiClient.IntrospectionEndpointApi.AuthIntrospectionApi(ctx).IntrospectionRequest(*introReq).Execute()
+	introResp, _, err := callWithRetry(t, "/auth/introspection", func() (*authlete.IntrospectionResponse, *http.Response, error) {
+		return apiClient.IntrospectionEndpointApi.AuthIntrospectionApi(ctx).IntrospectionRequest(*introReq).Execute()
+	})
 	if err != nil {
 		t.Fatalf("/auth/introspection failed: %v", err)
 	}

--- a/go/authorization_code_flow_test.go
+++ b/go/authorization_code_flow_test.go
@@ -15,6 +15,8 @@ import (
 const (
 	testRedirectURI = "https://sdk-playground.example.com/callback"
 	testSubject     = "sdk-playground-user"
+	// The V2 /client/create API requires a developer identifier.
+	testDeveloper = "sdk-playground-developer"
 )
 
 // TestAuthorizationCodeFlow runs a minimal OAuth 2.0 authorization code flow
@@ -54,6 +56,7 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 	clientName := "sdk-playground-smoke-" + randomString(t)
 	newClient := authlete.NewClient()
 	newClient.SetClientName(clientName)
+	newClient.SetDeveloper(testDeveloper)
 	newClient.SetClientType(authlete.CLIENTTYPE_CONFIDENTIAL)
 	newClient.SetGrantTypes([]authlete.GrantType{authlete.GRANTTYPE_AUTHORIZATION_CODE})
 	newClient.SetResponseTypes([]authlete.ResponseType{authlete.RESPONSETYPE_CODE})

--- a/go/authorization_code_flow_test.go
+++ b/go/authorization_code_flow_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	authlete "github.com/authlete/openapi-for-go"
+)
+
+const (
+	testRedirectURI = "https://sdk-playground.example.com/callback"
+	testSubject     = "sdk-playground-user"
+)
+
+// TestAuthorizationCodeFlow runs a minimal OAuth 2.0 authorization code flow
+// against the Authlete V2 API to verify that the SDK works in this environment:
+// create client -> /auth/authorization -> /auth/authorization/issue ->
+// /auth/token -> /auth/introspection -> delete client.
+func TestAuthorizationCodeFlow(t *testing.T) {
+	baseURL := os.Getenv("AUTHLETE_BASE_URL")
+	apiKey := os.Getenv("AUTHLETE_SERVICE_APIKEY")
+	apiSecret := os.Getenv("AUTHLETE_SERVICE_APISECRET")
+	apiVersion := os.Getenv("AUTHLETE_API_VERSION")
+
+	if v := strings.TrimSpace(apiVersion); strings.EqualFold(v, "V3") || v == "3" {
+		t.Skip("openapi-for-go supports only the Authlete V2 API")
+	}
+	if baseURL == "" || apiKey == "" || apiSecret == "" {
+		t.Skip("AUTHLETE_BASE_URL, AUTHLETE_SERVICE_APIKEY and AUTHLETE_SERVICE_APISECRET are required")
+	}
+
+	apiClient, err := createSimpleClient(baseURL, apiVersion)
+	if err != nil {
+		t.Fatalf("failed to create Authlete client: %v", err)
+	}
+
+	ctx, err := createAPIContext(apiKey, apiSecret, "", apiVersion)
+	if err != nil {
+		t.Fatalf("failed to create API context: %v", err)
+	}
+
+	// Step 1: create a disposable client for this test.
+	clientName := "sdk-playground-smoke-" + randomString(t)
+	newClient := authlete.NewClient()
+	newClient.SetClientName(clientName)
+	newClient.SetClientType(authlete.CLIENTTYPE_CONFIDENTIAL)
+	newClient.SetGrantTypes([]authlete.GrantType{authlete.GRANTTYPE_AUTHORIZATION_CODE})
+	newClient.SetResponseTypes([]authlete.ResponseType{authlete.RESPONSETYPE_CODE})
+	newClient.SetRedirectUris([]string{testRedirectURI})
+
+	created, _, err := apiClient.ClientManagementApi.ClientCreateApi(ctx).Client(*newClient).Execute()
+	if err != nil {
+		t.Fatalf("/client/create failed: %v", err)
+	}
+	clientID := created.GetClientId()
+	t.Logf("created client: id=%d name=%s", clientID, clientName)
+
+	// Always clean up the client, even when the flow fails halfway.
+	defer func() {
+		_, err := apiClient.ClientManagementApi.ClientDeleteApi(ctx, fmt.Sprintf("%d", clientID)).Execute()
+		if err != nil {
+			t.Errorf("/client/delete failed for client %d: %v", clientID, err)
+			return
+		}
+		t.Logf("deleted client: id=%d", clientID)
+	}()
+
+	// Step 2: /auth/authorization
+	state := randomString(t)
+	authzParams := url.Values{}
+	authzParams.Set("response_type", "code")
+	authzParams.Set("client_id", fmt.Sprintf("%d", clientID))
+	authzParams.Set("redirect_uri", testRedirectURI)
+	authzParams.Set("state", state)
+
+	authzReq := authlete.NewAuthorizationRequest(authzParams.Encode())
+	authzResp, _, err := apiClient.AuthorizationEndpointApi.AuthAuthorizationApi(ctx).AuthorizationRequest(*authzReq).Execute()
+	if err != nil {
+		t.Fatalf("/auth/authorization failed: %v", err)
+	}
+	if action := authzResp.GetAction(); action != "INTERACTION" {
+		t.Fatalf("/auth/authorization: expected action INTERACTION, got %q", action)
+	}
+	ticket := authzResp.GetTicket()
+	if ticket == "" {
+		t.Fatal("/auth/authorization: ticket is empty")
+	}
+	t.Logf("/auth/authorization: action=INTERACTION ticket issued")
+
+	// Step 3: /auth/authorization/issue
+	issueReq := authlete.NewAuthorizationIssueRequest(ticket, testSubject)
+	issueResp, _, err := apiClient.AuthorizationEndpointApi.AuthAuthorizationIssueApi(ctx).AuthorizationIssueRequest(*issueReq).Execute()
+	if err != nil {
+		t.Fatalf("/auth/authorization/issue failed: %v", err)
+	}
+	if action := issueResp.GetAction(); action != "LOCATION" {
+		t.Fatalf("/auth/authorization/issue: expected action LOCATION, got %q", action)
+	}
+	location := issueResp.GetResponseContent()
+	if !strings.Contains(location, "code=") {
+		t.Fatalf("/auth/authorization/issue: no authorization code in response content: %s", location)
+	}
+	redirect, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("/auth/authorization/issue: failed to parse redirect URL %q: %v", location, err)
+	}
+	if got := redirect.Query().Get("state"); got != state {
+		t.Fatalf("/auth/authorization/issue: expected state %q, got %q", state, got)
+	}
+	code := redirect.Query().Get("code")
+	if code == "" {
+		t.Fatalf("/auth/authorization/issue: empty authorization code in %q", location)
+	}
+	t.Logf("/auth/authorization/issue: action=LOCATION authorization code issued")
+
+	// Step 4: /auth/token
+	tokenParams := url.Values{}
+	tokenParams.Set("grant_type", "authorization_code")
+	tokenParams.Set("code", code)
+	tokenParams.Set("redirect_uri", testRedirectURI)
+
+	tokenReq := authlete.NewTokenRequest(tokenParams.Encode())
+	tokenReq.SetClientId(fmt.Sprintf("%d", clientID))
+	tokenReq.SetClientSecret(created.GetClientSecret())
+	tokenResp, _, err := apiClient.TokenEndpointApi.AuthTokenApi(ctx).TokenRequest(*tokenReq).Execute()
+	if err != nil {
+		t.Fatalf("/auth/token failed: %v", err)
+	}
+	if action := tokenResp.GetAction(); action != "OK" {
+		t.Fatalf("/auth/token: expected action OK, got %q (%s)", action, tokenResp.GetResponseContent())
+	}
+	accessToken := tokenResp.GetAccessToken()
+	if accessToken == "" {
+		t.Fatal("/auth/token: access token is empty")
+	}
+	t.Logf("/auth/token: action=OK access token issued")
+
+	// Step 5: /auth/introspection
+	introReq := authlete.NewIntrospectionRequest(accessToken)
+	introResp, _, err := apiClient.IntrospectionEndpointApi.AuthIntrospectionApi(ctx).IntrospectionRequest(*introReq).Execute()
+	if err != nil {
+		t.Fatalf("/auth/introspection failed: %v", err)
+	}
+	if action := introResp.GetAction(); action != "OK" {
+		t.Fatalf("/auth/introspection: expected action OK, got %q", action)
+	}
+	if !introResp.GetUsable() {
+		t.Fatal("/auth/introspection: access token is not usable")
+	}
+	if subject := introResp.GetSubject(); subject != testSubject {
+		t.Fatalf("/auth/introspection: expected subject %q, got %q", testSubject, subject)
+	}
+	t.Logf("/auth/introspection: action=OK access token is valid")
+}
+
+func randomString(t *testing.T) string {
+	t.Helper()
+
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatalf("failed to generate random string: %v", err)
+	}
+	return hex.EncodeToString(buf)
+}

--- a/go/authorization_code_flow_test.go
+++ b/go/authorization_code_flow_test.go
@@ -22,24 +22,30 @@ const (
 // create client -> /auth/authorization -> /auth/authorization/issue ->
 // /auth/token -> /auth/introspection -> delete client.
 func TestAuthorizationCodeFlow(t *testing.T) {
-	baseURL := os.Getenv("AUTHLETE_BASE_URL")
-	apiKey := os.Getenv("AUTHLETE_SERVICE_APIKEY")
-	apiSecret := os.Getenv("AUTHLETE_SERVICE_APISECRET")
-	apiVersion := os.Getenv("AUTHLETE_API_VERSION")
+	// Prefer the version-specific variables; fall back to the plain ones
+	// when they hold a V2 configuration.
+	baseURL := os.Getenv("AUTHLETE_V2_BASE_URL")
+	apiKey := os.Getenv("AUTHLETE_V2_SERVICE_APIKEY")
+	apiSecret := os.Getenv("AUTHLETE_V2_SERVICE_APISECRET")
 
-	if v := strings.TrimSpace(apiVersion); strings.EqualFold(v, "V3") || v == "3" {
-		t.Skip("openapi-for-go supports only the Authlete V2 API")
+	if baseURL == "" && apiKey == "" && apiSecret == "" {
+		if v := strings.TrimSpace(os.Getenv("AUTHLETE_API_VERSION")); strings.EqualFold(v, "V3") || v == "3" {
+			t.Skip("openapi-for-go supports only the Authlete V2 API")
+		}
+		baseURL = os.Getenv("AUTHLETE_BASE_URL")
+		apiKey = os.Getenv("AUTHLETE_SERVICE_APIKEY")
+		apiSecret = os.Getenv("AUTHLETE_SERVICE_APISECRET")
 	}
 	if baseURL == "" || apiKey == "" || apiSecret == "" {
-		t.Skip("AUTHLETE_BASE_URL, AUTHLETE_SERVICE_APIKEY and AUTHLETE_SERVICE_APISECRET are required")
+		t.Skip("AUTHLETE_V2_BASE_URL, AUTHLETE_V2_SERVICE_APIKEY and AUTHLETE_V2_SERVICE_APISECRET (or plain AUTHLETE_* V2 credentials) are required")
 	}
 
-	apiClient, err := createSimpleClient(baseURL, apiVersion)
+	apiClient, err := createSimpleClient(baseURL, "")
 	if err != nil {
 		t.Fatalf("failed to create Authlete client: %v", err)
 	}
 
-	ctx, err := createAPIContext(apiKey, apiSecret, "", apiVersion)
+	ctx, err := createAPIContext(apiKey, apiSecret, "", "")
 	if err != nil {
 		t.Fatalf("failed to create API context: %v", err)
 	}

--- a/java-jakarta/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
+++ b/java-jakarta/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
@@ -1,0 +1,267 @@
+package com.authlete.sdklab;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import com.authlete.common.api.AuthleteApi;
+import com.authlete.common.api.AuthleteApiFactory;
+import com.authlete.common.conf.AuthleteSimpleConfiguration;
+import com.authlete.common.dto.AuthorizationIssueRequest;
+import com.authlete.common.dto.AuthorizationIssueResponse;
+import com.authlete.common.dto.AuthorizationRequest;
+import com.authlete.common.dto.AuthorizationResponse;
+import com.authlete.common.dto.Client;
+import com.authlete.common.dto.IntrospectionRequest;
+import com.authlete.common.dto.IntrospectionResponse;
+import com.authlete.common.dto.TokenRequest;
+import com.authlete.common.dto.TokenResponse;
+import com.authlete.common.types.ClientType;
+import com.authlete.common.types.GrantType;
+import com.authlete.common.types.ResponseType;
+
+/**
+ * Smoke test that runs a minimal OAuth 2.0 authorization code flow:
+ * create client -> /auth/authorization -> /auth/authorization/issue ->
+ * /auth/token -> /auth/introspection -> delete client.
+ *
+ * The V2 flow uses AUTHLETE_V2_BASE_URL / AUTHLETE_V2_SERVICE_APIKEY /
+ * AUTHLETE_V2_SERVICE_APISECRET, and the V3 flow uses AUTHLETE_V3_BASE_URL /
+ * AUTHLETE_V3_SERVICE_APIKEY / AUTHLETE_V3_SERVICE_ACCESSTOKEN. When the
+ * version-specific variables are not set, each flow falls back to the plain
+ * AUTHLETE_* variables if AUTHLETE_API_VERSION matches. A flow whose
+ * credentials are missing is skipped.
+ */
+public class AuthorizationCodeFlowSmokeTest {
+    private static final String REDIRECT_URI = "https://sdk-playground.example.com/callback";
+    private static final String SUBJECT = "sdk-playground-user";
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    @Test
+    void authorizationCodeFlowV2() {
+        String baseUrl = envOrFallback("AUTHLETE_V2_BASE_URL", "AUTHLETE_BASE_URL", !isV3Env());
+        String apiKey = envOrFallback("AUTHLETE_V2_SERVICE_APIKEY", "AUTHLETE_SERVICE_APIKEY", !isV3Env());
+        String apiSecret = envOrFallback("AUTHLETE_V2_SERVICE_APISECRET", "AUTHLETE_SERVICE_APISECRET", !isV3Env());
+
+        Assumptions.assumeTrue(!baseUrl.isBlank() && !apiKey.isBlank() && !apiSecret.isBlank(),
+                "Skipping V2 smoke test: AUTHLETE_V2_BASE_URL, AUTHLETE_V2_SERVICE_APIKEY and"
+                        + " AUTHLETE_V2_SERVICE_APISECRET (or plain AUTHLETE_* V2 credentials) are not set");
+
+        AuthleteApi api = AuthleteApiFactory.create(new AuthleteSimpleConfiguration()
+                .setApiVersion("V2")
+                .setBaseUrl(baseUrl)
+                .setServiceApiKey(apiKey)
+                .setServiceApiSecret(apiSecret));
+        assertNotNull(api, "Failed to create an AuthleteApi instance for V2");
+
+        runAuthorizationCodeFlow("V2", api);
+    }
+
+    @Test
+    void authorizationCodeFlowV3() {
+        String baseUrl = envOrFallback("AUTHLETE_V3_BASE_URL", "AUTHLETE_BASE_URL", isV3Env());
+        String apiKey = envOrFallback("AUTHLETE_V3_SERVICE_APIKEY", "AUTHLETE_SERVICE_APIKEY", isV3Env());
+        String accessToken = envOrFallback("AUTHLETE_V3_SERVICE_ACCESSTOKEN", "AUTHLETE_SERVICE_ACCESSTOKEN", isV3Env());
+
+        Assumptions.assumeTrue(!baseUrl.isBlank() && !apiKey.isBlank() && !accessToken.isBlank(),
+                "Skipping V3 smoke test: AUTHLETE_V3_BASE_URL, AUTHLETE_V3_SERVICE_APIKEY and"
+                        + " AUTHLETE_V3_SERVICE_ACCESSTOKEN (or plain AUTHLETE_* V3 credentials) are not set");
+
+        AuthleteApi api = AuthleteApiFactory.create(new AuthleteSimpleConfiguration()
+                .setApiVersion("V3")
+                .setBaseUrl(baseUrl)
+                .setServiceApiKey(apiKey)
+                .setServiceAccessToken(accessToken));
+        assertNotNull(api, "Failed to create an AuthleteApi instance for V3");
+
+        runAuthorizationCodeFlow("V3", api);
+    }
+
+    private static void runAuthorizationCodeFlow(String label, AuthleteApi api) {
+        Client createdClient = null;
+        Throwable failure = null;
+
+        try {
+            String clientName = "sdk-playground-smoke-" + randomAlnum(12);
+            String state = randomAlnum(24);
+
+            System.out.println("[smoke:" + label + "] Step 1: Creating a confidential authorization-code client: " + clientName);
+            Client clientRequest = new Client()
+                    .setClientName(clientName)
+                    .setClientType(ClientType.CONFIDENTIAL)
+                    .setGrantTypes(new GrantType[] { GrantType.AUTHORIZATION_CODE })
+                    .setResponseTypes(new ResponseType[] { ResponseType.CODE })
+                    .setRedirectUris(new String[] { REDIRECT_URI });
+            createdClient = api.createClient(clientRequest);
+            assertNotNull(createdClient, "Created client must not be null");
+            assertTrue(createdClient.getClientId() > 0, "Created client ID must be positive");
+            assertNotNull(createdClient.getClientSecret(), "Created client secret must not be null");
+            assertFalse(createdClient.getClientSecret().isBlank(), "Created client secret must not be blank");
+            System.out.println("[smoke:" + label + "] Step 1 result: clientId=" + createdClient.getClientId());
+
+            System.out.println("[smoke:" + label + "] Step 2: Calling /auth/authorization");
+            String authorizationParameters = "response_type=code"
+                    + "&client_id=" + createdClient.getClientId()
+                    + "&redirect_uri=" + encode(REDIRECT_URI)
+                    + "&state=" + encode(state);
+            AuthorizationRequest authorizationRequest = new AuthorizationRequest()
+                    .setParameters(authorizationParameters);
+            AuthorizationResponse authorizationResponse = api.authorization(authorizationRequest);
+            assertEquals(AuthorizationResponse.Action.INTERACTION, authorizationResponse.getAction(),
+                    "Authorization action must be INTERACTION");
+            assertNotNull(authorizationResponse.getTicket(), "Authorization ticket must not be null");
+            System.out.println("[smoke:" + label + "] Step 2 result: action=" + authorizationResponse.getAction());
+
+            System.out.println("[smoke:" + label + "] Step 3: Issuing authorization response");
+            AuthorizationIssueRequest issueRequest = new AuthorizationIssueRequest()
+                    .setTicket(authorizationResponse.getTicket())
+                    .setSubject(SUBJECT);
+            AuthorizationIssueResponse issueResponse = api.authorizationIssue(issueRequest);
+            assertEquals(AuthorizationIssueResponse.Action.LOCATION, issueResponse.getAction(),
+                    "Authorization issue action must be LOCATION");
+            assertNotNull(issueResponse.getResponseContent(), "Authorization issue response content must not be null");
+            assertTrue(issueResponse.getResponseContent().contains("code="),
+                    "Redirect URL must contain an authorization code");
+            assertTrue(issueResponse.getResponseContent().contains("state=" + state),
+                    "Redirect URL must contain the original state");
+            System.out.println("[smoke:" + label + "] Step 3 result: action=" + issueResponse.getAction());
+
+            String authorizationCode = extractQueryParameter(issueResponse.getResponseContent(), "code");
+            assertNotNull(authorizationCode, "Authorization code must be present in the redirect URL");
+            assertFalse(authorizationCode.isBlank(), "Authorization code must not be blank");
+
+            System.out.println("[smoke:" + label + "] Step 4: Exchanging authorization code for tokens");
+            String tokenParameters = "grant_type=authorization_code"
+                    + "&code=" + encode(authorizationCode)
+                    + "&redirect_uri=" + encode(REDIRECT_URI);
+            TokenRequest tokenRequest = new TokenRequest()
+                    .setParameters(tokenParameters)
+                    .setClientId(String.valueOf(createdClient.getClientId()))
+                    .setClientSecret(createdClient.getClientSecret());
+            TokenResponse tokenResponse = api.token(tokenRequest);
+            assertEquals(TokenResponse.Action.OK, tokenResponse.getAction(), "Token action must be OK");
+            assertNotNull(tokenResponse.getAccessToken(), "Access token must not be null");
+            assertFalse(tokenResponse.getAccessToken().isBlank(), "Access token must not be blank");
+            System.out.println("[smoke:" + label + "] Step 4 result: action=" + tokenResponse.getAction());
+
+            System.out.println("[smoke:" + label + "] Step 5: Introspecting the access token");
+            IntrospectionRequest introspectionRequest = new IntrospectionRequest()
+                    .setToken(tokenResponse.getAccessToken());
+            IntrospectionResponse introspectionResponse = api.introspection(introspectionRequest);
+            assertEquals(IntrospectionResponse.Action.OK, introspectionResponse.getAction(),
+                    "Introspection action must be OK");
+            assertTrue(introspectionResponse.isUsable(), "Introspected access token must be usable");
+            assertEquals(SUBJECT, introspectionResponse.getSubject(),
+                    "Introspected access token must be bound to the test subject");
+            System.out.println("[smoke:" + label + "] Step 5 result: action=" + introspectionResponse.getAction()
+                    + ", subject=" + introspectionResponse.getSubject());
+        } catch (Throwable t) {
+            failure = t;
+        } finally {
+            // Delete the client without masking the original failure. A cleanup
+            // failure is reported as suppressed (or as the failure itself when
+            // the flow succeeded).
+            if (createdClient != null && createdClient.getClientId() > 0) {
+                System.out.println("[smoke:" + label + "] Cleanup: deleting clientId=" + createdClient.getClientId());
+                try {
+                    api.deleteClient(createdClient.getClientId());
+                    System.out.println("[smoke:" + label + "] Cleanup result: client deleted");
+                } catch (RuntimeException e) {
+                    if (failure != null) {
+                        failure.addSuppressed(e);
+                    } else {
+                        failure = e;
+                    }
+                }
+            }
+        }
+
+        if (failure instanceof RuntimeException) {
+            throw (RuntimeException) failure;
+        }
+        if (failure instanceof Error) {
+            throw (Error) failure;
+        }
+        if (failure != null) {
+            throw new RuntimeException(failure);
+        }
+    }
+
+    /**
+     * Returns the value of {@code primaryName}. When it is not set and
+     * {@code fallbackAllowed} is true, returns the value of
+     * {@code fallbackName} instead.
+     */
+    private static String envOrFallback(String primaryName, String fallbackName, boolean fallbackAllowed) {
+        String primary = env(primaryName);
+
+        if (!primary.isBlank() || !fallbackAllowed) {
+            return primary;
+        }
+
+        return env(fallbackName);
+    }
+
+    private static boolean isV3Env() {
+        String version = env("AUTHLETE_API_VERSION");
+        return version.equalsIgnoreCase("3") || version.equalsIgnoreCase("V3");
+    }
+
+    private static String env(String name) {
+        String value = System.getenv(name);
+        return value == null ? "" : value.trim();
+    }
+
+    private static String randomAlnum(int length) {
+        final String alphabet = "abcdefghijklmnopqrstuvwxyz0123456789";
+        StringBuilder builder = new StringBuilder(length);
+
+        for (int i = 0; i < length; i++) {
+            builder.append(alphabet.charAt(RANDOM.nextInt(alphabet.length())));
+        }
+
+        return builder.toString();
+    }
+
+    private static String encode(String value) {
+        return java.net.URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private static String extractQueryParameter(String url, String name) {
+        URI uri = URI.create(url);
+        Map<String, String> queryParameters = parseQuery(uri.getRawQuery());
+        return queryParameters.get(name);
+    }
+
+    private static Map<String, String> parseQuery(String query) {
+        Map<String, String> parameters = new LinkedHashMap<>();
+
+        if (query == null || query.isBlank()) {
+            return parameters;
+        }
+
+        for (String pair : query.split("&")) {
+            String[] elements = pair.split("=", 2);
+            String key = decode(elements[0]);
+            String value = elements.length > 1 ? decode(elements[1]) : "";
+            parameters.put(key, value);
+        }
+
+        return parameters;
+    }
+
+    private static String decode(String value) {
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/java-jakarta/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
+++ b/java-jakarta/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
@@ -10,12 +10,14 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import com.authlete.common.api.AuthleteApi;
+import com.authlete.common.api.AuthleteApiException;
 import com.authlete.common.api.AuthleteApiFactory;
 import com.authlete.common.conf.AuthleteSimpleConfiguration;
 import com.authlete.common.dto.AuthorizationIssueRequest;
@@ -48,6 +50,8 @@ public class AuthorizationCodeFlowSmokeTest {
     private static final String SUBJECT = "sdk-playground-user";
     // The V2 /client/create API requires a developer identifier.
     private static final String DEVELOPER = "sdk-playground-developer";
+    // Transient errors (429 and 5xx) are retried with exponential backoff.
+    private static final int MAX_RETRIES = 3;
     private static final SecureRandom RANDOM = new SecureRandom();
 
     @Test
@@ -113,7 +117,7 @@ public class AuthorizationCodeFlowSmokeTest {
                     .setGrantTypes(new GrantType[] { GrantType.AUTHORIZATION_CODE })
                     .setResponseTypes(new ResponseType[] { ResponseType.CODE })
                     .setRedirectUris(new String[] { REDIRECT_URI });
-            createdClient = api.createClient(clientRequest);
+            createdClient = callWithRetry(label, "/client/create", () -> api.createClient(clientRequest));
             assertNotNull(createdClient, "Created client must not be null");
             assertTrue(createdClient.getClientId() > 0, "Created client ID must be positive");
             assertNotNull(createdClient.getClientSecret(), "Created client secret must not be null");
@@ -127,7 +131,8 @@ public class AuthorizationCodeFlowSmokeTest {
                     + "&state=" + encode(state);
             AuthorizationRequest authorizationRequest = new AuthorizationRequest()
                     .setParameters(authorizationParameters);
-            AuthorizationResponse authorizationResponse = api.authorization(authorizationRequest);
+            AuthorizationResponse authorizationResponse =
+                    callWithRetry(label, "/auth/authorization", () -> api.authorization(authorizationRequest));
             assertEquals(AuthorizationResponse.Action.INTERACTION, authorizationResponse.getAction(),
                     "Authorization action must be INTERACTION");
             assertNotNull(authorizationResponse.getTicket(), "Authorization ticket must not be null");
@@ -137,7 +142,8 @@ public class AuthorizationCodeFlowSmokeTest {
             AuthorizationIssueRequest issueRequest = new AuthorizationIssueRequest()
                     .setTicket(authorizationResponse.getTicket())
                     .setSubject(SUBJECT);
-            AuthorizationIssueResponse issueResponse = api.authorizationIssue(issueRequest);
+            AuthorizationIssueResponse issueResponse =
+                    callWithRetry(label, "/auth/authorization/issue", () -> api.authorizationIssue(issueRequest));
             assertEquals(AuthorizationIssueResponse.Action.LOCATION, issueResponse.getAction(),
                     "Authorization issue action must be LOCATION");
             assertNotNull(issueResponse.getResponseContent(), "Authorization issue response content must not be null");
@@ -159,7 +165,7 @@ public class AuthorizationCodeFlowSmokeTest {
                     .setParameters(tokenParameters)
                     .setClientId(String.valueOf(createdClient.getClientId()))
                     .setClientSecret(createdClient.getClientSecret());
-            TokenResponse tokenResponse = api.token(tokenRequest);
+            TokenResponse tokenResponse = callWithRetry(label, "/auth/token", () -> api.token(tokenRequest));
             assertEquals(TokenResponse.Action.OK, tokenResponse.getAction(), "Token action must be OK");
             assertNotNull(tokenResponse.getAccessToken(), "Access token must not be null");
             assertFalse(tokenResponse.getAccessToken().isBlank(), "Access token must not be blank");
@@ -168,7 +174,8 @@ public class AuthorizationCodeFlowSmokeTest {
             System.out.println("[smoke:" + label + "] Step 5: Introspecting the access token");
             IntrospectionRequest introspectionRequest = new IntrospectionRequest()
                     .setToken(tokenResponse.getAccessToken());
-            IntrospectionResponse introspectionResponse = api.introspection(introspectionRequest);
+            IntrospectionResponse introspectionResponse =
+                    callWithRetry(label, "/auth/introspection", () -> api.introspection(introspectionRequest));
             assertEquals(IntrospectionResponse.Action.OK, introspectionResponse.getAction(),
                     "Introspection action must be OK");
             assertTrue(introspectionResponse.isUsable(), "Introspected access token must be usable");
@@ -185,8 +192,12 @@ public class AuthorizationCodeFlowSmokeTest {
             if (createdClient != null && createdClient.getClientId() > 0) {
                 System.out.println("[smoke:" + label + "] Cleanup: deleting clientId=" + createdClient.getClientId());
                 try {
-                    api.deleteClient(createdClient.getClientId());
-                    verifyClientDeleted(api, createdClient.getClientId());
+                    long clientId = createdClient.getClientId();
+                    callWithRetry(label, "/client/delete", () -> {
+                        api.deleteClient(clientId);
+                        return null;
+                    });
+                    verifyClientDeleted(label, api, clientId);
                     System.out.println("[smoke:" + label + "] Cleanup result: client deleted");
                 } catch (RuntimeException e) {
                     if (failure != null) {
@@ -215,9 +226,16 @@ public class AuthorizationCodeFlowSmokeTest {
      * the deletion, which would leak clients and eventually exhaust the
      * service's client quota.
      */
-    private static void verifyClientDeleted(AuthleteApi api, long clientId) {
+    private static void verifyClientDeleted(String label, AuthleteApi api, long clientId) {
         try {
-            api.getClient(clientId);
+            callWithRetry(label, "/client/get (verify deletion)", () -> api.getClient(clientId));
+        } catch (AuthleteApiException e) {
+            if (isRetryableStatus(e.getStatusCode())) {
+                throw new IllegalStateException(
+                        "Could not verify the deletion of client " + clientId, e);
+            }
+            // Expected: the client no longer exists.
+            return;
         } catch (RuntimeException e) {
             // Expected: the client no longer exists.
             return;
@@ -225,6 +243,78 @@ public class AuthorizationCodeFlowSmokeTest {
 
         throw new IllegalStateException(
                 "Client " + clientId + " still exists after deleteClient()");
+    }
+
+    @FunctionalInterface
+    private interface ApiCall<T> {
+        T call();
+    }
+
+    /**
+     * Executes an Authlete API call, retrying transient errors (429 and 5xx)
+     * following https://www.authlete.com/kb/deployment/performance/ratelimit-best-practices/:
+     * honor the Ratelimit-Reset header when present, otherwise use exponential
+     * backoff (500 ms, 1 s, 2 s) with a small random jitter.
+     */
+    private static <T> T callWithRetry(String label, String api, ApiCall<T> call) {
+        for (int attempt = 0; ; attempt++) {
+            try {
+                return call.call();
+            } catch (AuthleteApiException e) {
+                if (attempt >= MAX_RETRIES || !isRetryableStatus(e.getStatusCode())) {
+                    throw e;
+                }
+
+                long delayMillis = retryDelayMillis(attempt, e.getResponseHeaders());
+                System.out.println("[smoke:" + label + "] " + api + " failed with HTTP " + e.getStatusCode()
+                        + "; retrying in " + delayMillis + " ms (attempt " + (attempt + 1) + "/" + MAX_RETRIES + ")");
+                sleep(delayMillis);
+            }
+        }
+    }
+
+    private static boolean isRetryableStatus(int statusCode) {
+        return statusCode == 429 || statusCode >= 500;
+    }
+
+    private static long retryDelayMillis(int attempt, Map<String, List<String>> headers) {
+        long resetSeconds = ratelimitResetSeconds(headers);
+
+        if (resetSeconds > 0) {
+            return Math.min(resetSeconds, 30) * 1000L;
+        }
+
+        return (500L << attempt) + RANDOM.nextInt(250);
+    }
+
+    private static long ratelimitResetSeconds(Map<String, List<String>> headers) {
+        if (headers == null) {
+            return 0;
+        }
+
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            if (entry.getKey() == null || !entry.getKey().equalsIgnoreCase("Ratelimit-Reset")
+                    || entry.getValue() == null || entry.getValue().isEmpty()) {
+                continue;
+            }
+
+            try {
+                return Long.parseLong(entry.getValue().get(0).trim());
+            } catch (NumberFormatException e) {
+                return 0;
+            }
+        }
+
+        return 0;
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting to retry", e);
+        }
     }
 
     /**

--- a/java-jakarta/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
+++ b/java-jakarta/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
@@ -46,6 +46,8 @@ import com.authlete.common.types.ResponseType;
 public class AuthorizationCodeFlowSmokeTest {
     private static final String REDIRECT_URI = "https://sdk-playground.example.com/callback";
     private static final String SUBJECT = "sdk-playground-user";
+    // The V2 /client/create API requires a developer identifier.
+    private static final String DEVELOPER = "sdk-playground-developer";
     private static final SecureRandom RANDOM = new SecureRandom();
 
     @Test
@@ -58,11 +60,18 @@ public class AuthorizationCodeFlowSmokeTest {
                 "Skipping V2 smoke test: AUTHLETE_V2_BASE_URL, AUTHLETE_V2_SERVICE_APIKEY and"
                         + " AUTHLETE_V2_SERVICE_APISECRET (or plain AUTHLETE_* V2 credentials) are not set");
 
+        // The service-owner credentials are set to the service credentials on
+        // purpose: authlete-java-common's HttpURLConnection-based V2
+        // implementation (4.47) sends /api/client/delete with the
+        // service-owner credentials, and the server also accepts the service
+        // credentials there.
         AuthleteApi api = AuthleteApiFactory.create(new AuthleteSimpleConfiguration()
                 .setApiVersion("V2")
                 .setBaseUrl(baseUrl)
                 .setServiceApiKey(apiKey)
-                .setServiceApiSecret(apiSecret));
+                .setServiceApiSecret(apiSecret)
+                .setServiceOwnerApiKey(apiKey)
+                .setServiceOwnerApiSecret(apiSecret));
         assertNotNull(api, "Failed to create an AuthleteApi instance for V2");
 
         runAuthorizationCodeFlow("V2", api);
@@ -99,6 +108,7 @@ public class AuthorizationCodeFlowSmokeTest {
             System.out.println("[smoke:" + label + "] Step 1: Creating a confidential authorization-code client: " + clientName);
             Client clientRequest = new Client()
                     .setClientName(clientName)
+                    .setDeveloper(DEVELOPER)
                     .setClientType(ClientType.CONFIDENTIAL)
                     .setGrantTypes(new GrantType[] { GrantType.AUTHORIZATION_CODE })
                     .setResponseTypes(new ResponseType[] { ResponseType.CODE })
@@ -176,6 +186,7 @@ public class AuthorizationCodeFlowSmokeTest {
                 System.out.println("[smoke:" + label + "] Cleanup: deleting clientId=" + createdClient.getClientId());
                 try {
                     api.deleteClient(createdClient.getClientId());
+                    verifyClientDeleted(api, createdClient.getClientId());
                     System.out.println("[smoke:" + label + "] Cleanup result: client deleted");
                 } catch (RuntimeException e) {
                     if (failure != null) {
@@ -196,6 +207,24 @@ public class AuthorizationCodeFlowSmokeTest {
         if (failure != null) {
             throw new RuntimeException(failure);
         }
+    }
+
+    /**
+     * Ensures that the client has actually been deleted. Some SDK versions
+     * report success from {@code deleteClient} even when the server rejected
+     * the deletion, which would leak clients and eventually exhaust the
+     * service's client quota.
+     */
+    private static void verifyClientDeleted(AuthleteApi api, long clientId) {
+        try {
+            api.getClient(clientId);
+        } catch (RuntimeException e) {
+            // Expected: the client no longer exists.
+            return;
+        }
+
+        throw new IllegalStateException(
+                "Client " + clientId + " still exists after deleteClient()");
     }
 
     /**

--- a/java-jaxrs/pom.xml
+++ b/java-jaxrs/pom.xml
@@ -153,6 +153,12 @@
       <artifactId>gson</artifactId>
       <version>2.10.1</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java-jaxrs/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
+++ b/java-jaxrs/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
@@ -1,0 +1,267 @@
+package com.authlete.sdklab;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import com.authlete.common.api.AuthleteApi;
+import com.authlete.common.api.AuthleteApiFactory;
+import com.authlete.common.conf.AuthleteSimpleConfiguration;
+import com.authlete.common.dto.AuthorizationIssueRequest;
+import com.authlete.common.dto.AuthorizationIssueResponse;
+import com.authlete.common.dto.AuthorizationRequest;
+import com.authlete.common.dto.AuthorizationResponse;
+import com.authlete.common.dto.Client;
+import com.authlete.common.dto.IntrospectionRequest;
+import com.authlete.common.dto.IntrospectionResponse;
+import com.authlete.common.dto.TokenRequest;
+import com.authlete.common.dto.TokenResponse;
+import com.authlete.common.types.ClientType;
+import com.authlete.common.types.GrantType;
+import com.authlete.common.types.ResponseType;
+
+/**
+ * Smoke test that runs a minimal OAuth 2.0 authorization code flow:
+ * create client -> /auth/authorization -> /auth/authorization/issue ->
+ * /auth/token -> /auth/introspection -> delete client.
+ *
+ * The V2 flow uses AUTHLETE_V2_BASE_URL / AUTHLETE_V2_SERVICE_APIKEY /
+ * AUTHLETE_V2_SERVICE_APISECRET, and the V3 flow uses AUTHLETE_V3_BASE_URL /
+ * AUTHLETE_V3_SERVICE_APIKEY / AUTHLETE_V3_SERVICE_ACCESSTOKEN. When the
+ * version-specific variables are not set, each flow falls back to the plain
+ * AUTHLETE_* variables if AUTHLETE_API_VERSION matches. A flow whose
+ * credentials are missing is skipped.
+ */
+public class AuthorizationCodeFlowSmokeTest {
+    private static final String REDIRECT_URI = "https://sdk-playground.example.com/callback";
+    private static final String SUBJECT = "sdk-playground-user";
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    @Test
+    void authorizationCodeFlowV2() {
+        String baseUrl = envOrFallback("AUTHLETE_V2_BASE_URL", "AUTHLETE_BASE_URL", !isV3Env());
+        String apiKey = envOrFallback("AUTHLETE_V2_SERVICE_APIKEY", "AUTHLETE_SERVICE_APIKEY", !isV3Env());
+        String apiSecret = envOrFallback("AUTHLETE_V2_SERVICE_APISECRET", "AUTHLETE_SERVICE_APISECRET", !isV3Env());
+
+        Assumptions.assumeTrue(!baseUrl.isBlank() && !apiKey.isBlank() && !apiSecret.isBlank(),
+                "Skipping V2 smoke test: AUTHLETE_V2_BASE_URL, AUTHLETE_V2_SERVICE_APIKEY and"
+                        + " AUTHLETE_V2_SERVICE_APISECRET (or plain AUTHLETE_* V2 credentials) are not set");
+
+        AuthleteApi api = AuthleteApiFactory.create(new AuthleteSimpleConfiguration()
+                .setApiVersion("V2")
+                .setBaseUrl(baseUrl)
+                .setServiceApiKey(apiKey)
+                .setServiceApiSecret(apiSecret));
+        assertNotNull(api, "Failed to create an AuthleteApi instance for V2");
+
+        runAuthorizationCodeFlow("V2", api);
+    }
+
+    @Test
+    void authorizationCodeFlowV3() {
+        String baseUrl = envOrFallback("AUTHLETE_V3_BASE_URL", "AUTHLETE_BASE_URL", isV3Env());
+        String apiKey = envOrFallback("AUTHLETE_V3_SERVICE_APIKEY", "AUTHLETE_SERVICE_APIKEY", isV3Env());
+        String accessToken = envOrFallback("AUTHLETE_V3_SERVICE_ACCESSTOKEN", "AUTHLETE_SERVICE_ACCESSTOKEN", isV3Env());
+
+        Assumptions.assumeTrue(!baseUrl.isBlank() && !apiKey.isBlank() && !accessToken.isBlank(),
+                "Skipping V3 smoke test: AUTHLETE_V3_BASE_URL, AUTHLETE_V3_SERVICE_APIKEY and"
+                        + " AUTHLETE_V3_SERVICE_ACCESSTOKEN (or plain AUTHLETE_* V3 credentials) are not set");
+
+        AuthleteApi api = AuthleteApiFactory.create(new AuthleteSimpleConfiguration()
+                .setApiVersion("V3")
+                .setBaseUrl(baseUrl)
+                .setServiceApiKey(apiKey)
+                .setServiceAccessToken(accessToken));
+        assertNotNull(api, "Failed to create an AuthleteApi instance for V3");
+
+        runAuthorizationCodeFlow("V3", api);
+    }
+
+    private static void runAuthorizationCodeFlow(String label, AuthleteApi api) {
+        Client createdClient = null;
+        Throwable failure = null;
+
+        try {
+            String clientName = "sdk-playground-smoke-" + randomAlnum(12);
+            String state = randomAlnum(24);
+
+            System.out.println("[smoke:" + label + "] Step 1: Creating a confidential authorization-code client: " + clientName);
+            Client clientRequest = new Client()
+                    .setClientName(clientName)
+                    .setClientType(ClientType.CONFIDENTIAL)
+                    .setGrantTypes(new GrantType[] { GrantType.AUTHORIZATION_CODE })
+                    .setResponseTypes(new ResponseType[] { ResponseType.CODE })
+                    .setRedirectUris(new String[] { REDIRECT_URI });
+            createdClient = api.createClient(clientRequest);
+            assertNotNull(createdClient, "Created client must not be null");
+            assertTrue(createdClient.getClientId() > 0, "Created client ID must be positive");
+            assertNotNull(createdClient.getClientSecret(), "Created client secret must not be null");
+            assertFalse(createdClient.getClientSecret().isBlank(), "Created client secret must not be blank");
+            System.out.println("[smoke:" + label + "] Step 1 result: clientId=" + createdClient.getClientId());
+
+            System.out.println("[smoke:" + label + "] Step 2: Calling /auth/authorization");
+            String authorizationParameters = "response_type=code"
+                    + "&client_id=" + createdClient.getClientId()
+                    + "&redirect_uri=" + encode(REDIRECT_URI)
+                    + "&state=" + encode(state);
+            AuthorizationRequest authorizationRequest = new AuthorizationRequest()
+                    .setParameters(authorizationParameters);
+            AuthorizationResponse authorizationResponse = api.authorization(authorizationRequest);
+            assertEquals(AuthorizationResponse.Action.INTERACTION, authorizationResponse.getAction(),
+                    "Authorization action must be INTERACTION");
+            assertNotNull(authorizationResponse.getTicket(), "Authorization ticket must not be null");
+            System.out.println("[smoke:" + label + "] Step 2 result: action=" + authorizationResponse.getAction());
+
+            System.out.println("[smoke:" + label + "] Step 3: Issuing authorization response");
+            AuthorizationIssueRequest issueRequest = new AuthorizationIssueRequest()
+                    .setTicket(authorizationResponse.getTicket())
+                    .setSubject(SUBJECT);
+            AuthorizationIssueResponse issueResponse = api.authorizationIssue(issueRequest);
+            assertEquals(AuthorizationIssueResponse.Action.LOCATION, issueResponse.getAction(),
+                    "Authorization issue action must be LOCATION");
+            assertNotNull(issueResponse.getResponseContent(), "Authorization issue response content must not be null");
+            assertTrue(issueResponse.getResponseContent().contains("code="),
+                    "Redirect URL must contain an authorization code");
+            assertTrue(issueResponse.getResponseContent().contains("state=" + state),
+                    "Redirect URL must contain the original state");
+            System.out.println("[smoke:" + label + "] Step 3 result: action=" + issueResponse.getAction());
+
+            String authorizationCode = extractQueryParameter(issueResponse.getResponseContent(), "code");
+            assertNotNull(authorizationCode, "Authorization code must be present in the redirect URL");
+            assertFalse(authorizationCode.isBlank(), "Authorization code must not be blank");
+
+            System.out.println("[smoke:" + label + "] Step 4: Exchanging authorization code for tokens");
+            String tokenParameters = "grant_type=authorization_code"
+                    + "&code=" + encode(authorizationCode)
+                    + "&redirect_uri=" + encode(REDIRECT_URI);
+            TokenRequest tokenRequest = new TokenRequest()
+                    .setParameters(tokenParameters)
+                    .setClientId(String.valueOf(createdClient.getClientId()))
+                    .setClientSecret(createdClient.getClientSecret());
+            TokenResponse tokenResponse = api.token(tokenRequest);
+            assertEquals(TokenResponse.Action.OK, tokenResponse.getAction(), "Token action must be OK");
+            assertNotNull(tokenResponse.getAccessToken(), "Access token must not be null");
+            assertFalse(tokenResponse.getAccessToken().isBlank(), "Access token must not be blank");
+            System.out.println("[smoke:" + label + "] Step 4 result: action=" + tokenResponse.getAction());
+
+            System.out.println("[smoke:" + label + "] Step 5: Introspecting the access token");
+            IntrospectionRequest introspectionRequest = new IntrospectionRequest()
+                    .setToken(tokenResponse.getAccessToken());
+            IntrospectionResponse introspectionResponse = api.introspection(introspectionRequest);
+            assertEquals(IntrospectionResponse.Action.OK, introspectionResponse.getAction(),
+                    "Introspection action must be OK");
+            assertTrue(introspectionResponse.isUsable(), "Introspected access token must be usable");
+            assertEquals(SUBJECT, introspectionResponse.getSubject(),
+                    "Introspected access token must be bound to the test subject");
+            System.out.println("[smoke:" + label + "] Step 5 result: action=" + introspectionResponse.getAction()
+                    + ", subject=" + introspectionResponse.getSubject());
+        } catch (Throwable t) {
+            failure = t;
+        } finally {
+            // Delete the client without masking the original failure. A cleanup
+            // failure is reported as suppressed (or as the failure itself when
+            // the flow succeeded).
+            if (createdClient != null && createdClient.getClientId() > 0) {
+                System.out.println("[smoke:" + label + "] Cleanup: deleting clientId=" + createdClient.getClientId());
+                try {
+                    api.deleteClient(createdClient.getClientId());
+                    System.out.println("[smoke:" + label + "] Cleanup result: client deleted");
+                } catch (RuntimeException e) {
+                    if (failure != null) {
+                        failure.addSuppressed(e);
+                    } else {
+                        failure = e;
+                    }
+                }
+            }
+        }
+
+        if (failure instanceof RuntimeException) {
+            throw (RuntimeException) failure;
+        }
+        if (failure instanceof Error) {
+            throw (Error) failure;
+        }
+        if (failure != null) {
+            throw new RuntimeException(failure);
+        }
+    }
+
+    /**
+     * Returns the value of {@code primaryName}. When it is not set and
+     * {@code fallbackAllowed} is true, returns the value of
+     * {@code fallbackName} instead.
+     */
+    private static String envOrFallback(String primaryName, String fallbackName, boolean fallbackAllowed) {
+        String primary = env(primaryName);
+
+        if (!primary.isBlank() || !fallbackAllowed) {
+            return primary;
+        }
+
+        return env(fallbackName);
+    }
+
+    private static boolean isV3Env() {
+        String version = env("AUTHLETE_API_VERSION");
+        return version.equalsIgnoreCase("3") || version.equalsIgnoreCase("V3");
+    }
+
+    private static String env(String name) {
+        String value = System.getenv(name);
+        return value == null ? "" : value.trim();
+    }
+
+    private static String randomAlnum(int length) {
+        final String alphabet = "abcdefghijklmnopqrstuvwxyz0123456789";
+        StringBuilder builder = new StringBuilder(length);
+
+        for (int i = 0; i < length; i++) {
+            builder.append(alphabet.charAt(RANDOM.nextInt(alphabet.length())));
+        }
+
+        return builder.toString();
+    }
+
+    private static String encode(String value) {
+        return java.net.URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private static String extractQueryParameter(String url, String name) {
+        URI uri = URI.create(url);
+        Map<String, String> queryParameters = parseQuery(uri.getRawQuery());
+        return queryParameters.get(name);
+    }
+
+    private static Map<String, String> parseQuery(String query) {
+        Map<String, String> parameters = new LinkedHashMap<>();
+
+        if (query == null || query.isBlank()) {
+            return parameters;
+        }
+
+        for (String pair : query.split("&")) {
+            String[] elements = pair.split("=", 2);
+            String key = decode(elements[0]);
+            String value = elements.length > 1 ? decode(elements[1]) : "";
+            parameters.put(key, value);
+        }
+
+        return parameters;
+    }
+
+    private static String decode(String value) {
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/java-jaxrs/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
+++ b/java-jaxrs/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
@@ -10,12 +10,14 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import com.authlete.common.api.AuthleteApi;
+import com.authlete.common.api.AuthleteApiException;
 import com.authlete.common.api.AuthleteApiFactory;
 import com.authlete.common.conf.AuthleteSimpleConfiguration;
 import com.authlete.common.dto.AuthorizationIssueRequest;
@@ -48,6 +50,8 @@ public class AuthorizationCodeFlowSmokeTest {
     private static final String SUBJECT = "sdk-playground-user";
     // The V2 /client/create API requires a developer identifier.
     private static final String DEVELOPER = "sdk-playground-developer";
+    // Transient errors (429 and 5xx) are retried with exponential backoff.
+    private static final int MAX_RETRIES = 3;
     private static final SecureRandom RANDOM = new SecureRandom();
 
     @Test
@@ -113,7 +117,7 @@ public class AuthorizationCodeFlowSmokeTest {
                     .setGrantTypes(new GrantType[] { GrantType.AUTHORIZATION_CODE })
                     .setResponseTypes(new ResponseType[] { ResponseType.CODE })
                     .setRedirectUris(new String[] { REDIRECT_URI });
-            createdClient = api.createClient(clientRequest);
+            createdClient = callWithRetry(label, "/client/create", () -> api.createClient(clientRequest));
             assertNotNull(createdClient, "Created client must not be null");
             assertTrue(createdClient.getClientId() > 0, "Created client ID must be positive");
             assertNotNull(createdClient.getClientSecret(), "Created client secret must not be null");
@@ -127,7 +131,8 @@ public class AuthorizationCodeFlowSmokeTest {
                     + "&state=" + encode(state);
             AuthorizationRequest authorizationRequest = new AuthorizationRequest()
                     .setParameters(authorizationParameters);
-            AuthorizationResponse authorizationResponse = api.authorization(authorizationRequest);
+            AuthorizationResponse authorizationResponse =
+                    callWithRetry(label, "/auth/authorization", () -> api.authorization(authorizationRequest));
             assertEquals(AuthorizationResponse.Action.INTERACTION, authorizationResponse.getAction(),
                     "Authorization action must be INTERACTION");
             assertNotNull(authorizationResponse.getTicket(), "Authorization ticket must not be null");
@@ -137,7 +142,8 @@ public class AuthorizationCodeFlowSmokeTest {
             AuthorizationIssueRequest issueRequest = new AuthorizationIssueRequest()
                     .setTicket(authorizationResponse.getTicket())
                     .setSubject(SUBJECT);
-            AuthorizationIssueResponse issueResponse = api.authorizationIssue(issueRequest);
+            AuthorizationIssueResponse issueResponse =
+                    callWithRetry(label, "/auth/authorization/issue", () -> api.authorizationIssue(issueRequest));
             assertEquals(AuthorizationIssueResponse.Action.LOCATION, issueResponse.getAction(),
                     "Authorization issue action must be LOCATION");
             assertNotNull(issueResponse.getResponseContent(), "Authorization issue response content must not be null");
@@ -159,7 +165,7 @@ public class AuthorizationCodeFlowSmokeTest {
                     .setParameters(tokenParameters)
                     .setClientId(String.valueOf(createdClient.getClientId()))
                     .setClientSecret(createdClient.getClientSecret());
-            TokenResponse tokenResponse = api.token(tokenRequest);
+            TokenResponse tokenResponse = callWithRetry(label, "/auth/token", () -> api.token(tokenRequest));
             assertEquals(TokenResponse.Action.OK, tokenResponse.getAction(), "Token action must be OK");
             assertNotNull(tokenResponse.getAccessToken(), "Access token must not be null");
             assertFalse(tokenResponse.getAccessToken().isBlank(), "Access token must not be blank");
@@ -168,7 +174,8 @@ public class AuthorizationCodeFlowSmokeTest {
             System.out.println("[smoke:" + label + "] Step 5: Introspecting the access token");
             IntrospectionRequest introspectionRequest = new IntrospectionRequest()
                     .setToken(tokenResponse.getAccessToken());
-            IntrospectionResponse introspectionResponse = api.introspection(introspectionRequest);
+            IntrospectionResponse introspectionResponse =
+                    callWithRetry(label, "/auth/introspection", () -> api.introspection(introspectionRequest));
             assertEquals(IntrospectionResponse.Action.OK, introspectionResponse.getAction(),
                     "Introspection action must be OK");
             assertTrue(introspectionResponse.isUsable(), "Introspected access token must be usable");
@@ -185,8 +192,12 @@ public class AuthorizationCodeFlowSmokeTest {
             if (createdClient != null && createdClient.getClientId() > 0) {
                 System.out.println("[smoke:" + label + "] Cleanup: deleting clientId=" + createdClient.getClientId());
                 try {
-                    api.deleteClient(createdClient.getClientId());
-                    verifyClientDeleted(api, createdClient.getClientId());
+                    long clientId = createdClient.getClientId();
+                    callWithRetry(label, "/client/delete", () -> {
+                        api.deleteClient(clientId);
+                        return null;
+                    });
+                    verifyClientDeleted(label, api, clientId);
                     System.out.println("[smoke:" + label + "] Cleanup result: client deleted");
                 } catch (RuntimeException e) {
                     if (failure != null) {
@@ -215,9 +226,16 @@ public class AuthorizationCodeFlowSmokeTest {
      * the deletion, which would leak clients and eventually exhaust the
      * service's client quota.
      */
-    private static void verifyClientDeleted(AuthleteApi api, long clientId) {
+    private static void verifyClientDeleted(String label, AuthleteApi api, long clientId) {
         try {
-            api.getClient(clientId);
+            callWithRetry(label, "/client/get (verify deletion)", () -> api.getClient(clientId));
+        } catch (AuthleteApiException e) {
+            if (isRetryableStatus(e.getStatusCode())) {
+                throw new IllegalStateException(
+                        "Could not verify the deletion of client " + clientId, e);
+            }
+            // Expected: the client no longer exists.
+            return;
         } catch (RuntimeException e) {
             // Expected: the client no longer exists.
             return;
@@ -225,6 +243,78 @@ public class AuthorizationCodeFlowSmokeTest {
 
         throw new IllegalStateException(
                 "Client " + clientId + " still exists after deleteClient()");
+    }
+
+    @FunctionalInterface
+    private interface ApiCall<T> {
+        T call();
+    }
+
+    /**
+     * Executes an Authlete API call, retrying transient errors (429 and 5xx)
+     * following https://www.authlete.com/kb/deployment/performance/ratelimit-best-practices/:
+     * honor the Ratelimit-Reset header when present, otherwise use exponential
+     * backoff (500 ms, 1 s, 2 s) with a small random jitter.
+     */
+    private static <T> T callWithRetry(String label, String api, ApiCall<T> call) {
+        for (int attempt = 0; ; attempt++) {
+            try {
+                return call.call();
+            } catch (AuthleteApiException e) {
+                if (attempt >= MAX_RETRIES || !isRetryableStatus(e.getStatusCode())) {
+                    throw e;
+                }
+
+                long delayMillis = retryDelayMillis(attempt, e.getResponseHeaders());
+                System.out.println("[smoke:" + label + "] " + api + " failed with HTTP " + e.getStatusCode()
+                        + "; retrying in " + delayMillis + " ms (attempt " + (attempt + 1) + "/" + MAX_RETRIES + ")");
+                sleep(delayMillis);
+            }
+        }
+    }
+
+    private static boolean isRetryableStatus(int statusCode) {
+        return statusCode == 429 || statusCode >= 500;
+    }
+
+    private static long retryDelayMillis(int attempt, Map<String, List<String>> headers) {
+        long resetSeconds = ratelimitResetSeconds(headers);
+
+        if (resetSeconds > 0) {
+            return Math.min(resetSeconds, 30) * 1000L;
+        }
+
+        return (500L << attempt) + RANDOM.nextInt(250);
+    }
+
+    private static long ratelimitResetSeconds(Map<String, List<String>> headers) {
+        if (headers == null) {
+            return 0;
+        }
+
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            if (entry.getKey() == null || !entry.getKey().equalsIgnoreCase("Ratelimit-Reset")
+                    || entry.getValue() == null || entry.getValue().isEmpty()) {
+                continue;
+            }
+
+            try {
+                return Long.parseLong(entry.getValue().get(0).trim());
+            } catch (NumberFormatException e) {
+                return 0;
+            }
+        }
+
+        return 0;
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting to retry", e);
+        }
     }
 
     /**

--- a/java-jaxrs/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
+++ b/java-jaxrs/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
@@ -46,6 +46,8 @@ import com.authlete.common.types.ResponseType;
 public class AuthorizationCodeFlowSmokeTest {
     private static final String REDIRECT_URI = "https://sdk-playground.example.com/callback";
     private static final String SUBJECT = "sdk-playground-user";
+    // The V2 /client/create API requires a developer identifier.
+    private static final String DEVELOPER = "sdk-playground-developer";
     private static final SecureRandom RANDOM = new SecureRandom();
 
     @Test
@@ -58,11 +60,18 @@ public class AuthorizationCodeFlowSmokeTest {
                 "Skipping V2 smoke test: AUTHLETE_V2_BASE_URL, AUTHLETE_V2_SERVICE_APIKEY and"
                         + " AUTHLETE_V2_SERVICE_APISECRET (or plain AUTHLETE_* V2 credentials) are not set");
 
+        // The service-owner credentials are set to the service credentials on
+        // purpose: authlete-java-common's HttpURLConnection-based V2
+        // implementation (4.47) sends /api/client/delete with the
+        // service-owner credentials, and the server also accepts the service
+        // credentials there.
         AuthleteApi api = AuthleteApiFactory.create(new AuthleteSimpleConfiguration()
                 .setApiVersion("V2")
                 .setBaseUrl(baseUrl)
                 .setServiceApiKey(apiKey)
-                .setServiceApiSecret(apiSecret));
+                .setServiceApiSecret(apiSecret)
+                .setServiceOwnerApiKey(apiKey)
+                .setServiceOwnerApiSecret(apiSecret));
         assertNotNull(api, "Failed to create an AuthleteApi instance for V2");
 
         runAuthorizationCodeFlow("V2", api);
@@ -99,6 +108,7 @@ public class AuthorizationCodeFlowSmokeTest {
             System.out.println("[smoke:" + label + "] Step 1: Creating a confidential authorization-code client: " + clientName);
             Client clientRequest = new Client()
                     .setClientName(clientName)
+                    .setDeveloper(DEVELOPER)
                     .setClientType(ClientType.CONFIDENTIAL)
                     .setGrantTypes(new GrantType[] { GrantType.AUTHORIZATION_CODE })
                     .setResponseTypes(new ResponseType[] { ResponseType.CODE })
@@ -176,6 +186,7 @@ public class AuthorizationCodeFlowSmokeTest {
                 System.out.println("[smoke:" + label + "] Cleanup: deleting clientId=" + createdClient.getClientId());
                 try {
                     api.deleteClient(createdClient.getClientId());
+                    verifyClientDeleted(api, createdClient.getClientId());
                     System.out.println("[smoke:" + label + "] Cleanup result: client deleted");
                 } catch (RuntimeException e) {
                     if (failure != null) {
@@ -196,6 +207,24 @@ public class AuthorizationCodeFlowSmokeTest {
         if (failure != null) {
             throw new RuntimeException(failure);
         }
+    }
+
+    /**
+     * Ensures that the client has actually been deleted. Some SDK versions
+     * report success from {@code deleteClient} even when the server rejected
+     * the deletion, which would leak clients and eventually exhaust the
+     * service's client quota.
+     */
+    private static void verifyClientDeleted(AuthleteApi api, long clientId) {
+        try {
+            api.getClient(clientId);
+        } catch (RuntimeException e) {
+            // Expected: the client no longer exists.
+            return;
+        }
+
+        throw new IllegalStateException(
+                "Client " + clientId + " still exists after deleteClient()");
     }
 
     /**

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,6 +61,10 @@
           <artifactId>maven-jar-plugin</artifactId>
           <version>${maven.jar.plugin.version}</version>
         </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/java/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
+++ b/java/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
@@ -1,0 +1,267 @@
+package com.authlete.sdklab;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import com.authlete.common.api.AuthleteApi;
+import com.authlete.common.api.AuthleteApiFactory;
+import com.authlete.common.conf.AuthleteSimpleConfiguration;
+import com.authlete.common.dto.AuthorizationIssueRequest;
+import com.authlete.common.dto.AuthorizationIssueResponse;
+import com.authlete.common.dto.AuthorizationRequest;
+import com.authlete.common.dto.AuthorizationResponse;
+import com.authlete.common.dto.Client;
+import com.authlete.common.dto.IntrospectionRequest;
+import com.authlete.common.dto.IntrospectionResponse;
+import com.authlete.common.dto.TokenRequest;
+import com.authlete.common.dto.TokenResponse;
+import com.authlete.common.types.ClientType;
+import com.authlete.common.types.GrantType;
+import com.authlete.common.types.ResponseType;
+
+/**
+ * Smoke test that runs a minimal OAuth 2.0 authorization code flow:
+ * create client -> /auth/authorization -> /auth/authorization/issue ->
+ * /auth/token -> /auth/introspection -> delete client.
+ *
+ * The V2 flow uses AUTHLETE_V2_BASE_URL / AUTHLETE_V2_SERVICE_APIKEY /
+ * AUTHLETE_V2_SERVICE_APISECRET, and the V3 flow uses AUTHLETE_V3_BASE_URL /
+ * AUTHLETE_V3_SERVICE_APIKEY / AUTHLETE_V3_SERVICE_ACCESSTOKEN. When the
+ * version-specific variables are not set, each flow falls back to the plain
+ * AUTHLETE_* variables if AUTHLETE_API_VERSION matches. A flow whose
+ * credentials are missing is skipped.
+ */
+public class AuthorizationCodeFlowSmokeTest {
+    private static final String REDIRECT_URI = "https://sdk-playground.example.com/callback";
+    private static final String SUBJECT = "sdk-playground-user";
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    @Test
+    void authorizationCodeFlowV2() {
+        String baseUrl = envOrFallback("AUTHLETE_V2_BASE_URL", "AUTHLETE_BASE_URL", !isV3Env());
+        String apiKey = envOrFallback("AUTHLETE_V2_SERVICE_APIKEY", "AUTHLETE_SERVICE_APIKEY", !isV3Env());
+        String apiSecret = envOrFallback("AUTHLETE_V2_SERVICE_APISECRET", "AUTHLETE_SERVICE_APISECRET", !isV3Env());
+
+        Assumptions.assumeTrue(!baseUrl.isBlank() && !apiKey.isBlank() && !apiSecret.isBlank(),
+                "Skipping V2 smoke test: AUTHLETE_V2_BASE_URL, AUTHLETE_V2_SERVICE_APIKEY and"
+                        + " AUTHLETE_V2_SERVICE_APISECRET (or plain AUTHLETE_* V2 credentials) are not set");
+
+        AuthleteApi api = AuthleteApiFactory.create(new AuthleteSimpleConfiguration()
+                .setApiVersion("V2")
+                .setBaseUrl(baseUrl)
+                .setServiceApiKey(apiKey)
+                .setServiceApiSecret(apiSecret));
+        assertNotNull(api, "Failed to create an AuthleteApi instance for V2");
+
+        runAuthorizationCodeFlow("V2", api);
+    }
+
+    @Test
+    void authorizationCodeFlowV3() {
+        String baseUrl = envOrFallback("AUTHLETE_V3_BASE_URL", "AUTHLETE_BASE_URL", isV3Env());
+        String apiKey = envOrFallback("AUTHLETE_V3_SERVICE_APIKEY", "AUTHLETE_SERVICE_APIKEY", isV3Env());
+        String accessToken = envOrFallback("AUTHLETE_V3_SERVICE_ACCESSTOKEN", "AUTHLETE_SERVICE_ACCESSTOKEN", isV3Env());
+
+        Assumptions.assumeTrue(!baseUrl.isBlank() && !apiKey.isBlank() && !accessToken.isBlank(),
+                "Skipping V3 smoke test: AUTHLETE_V3_BASE_URL, AUTHLETE_V3_SERVICE_APIKEY and"
+                        + " AUTHLETE_V3_SERVICE_ACCESSTOKEN (or plain AUTHLETE_* V3 credentials) are not set");
+
+        AuthleteApi api = AuthleteApiFactory.create(new AuthleteSimpleConfiguration()
+                .setApiVersion("V3")
+                .setBaseUrl(baseUrl)
+                .setServiceApiKey(apiKey)
+                .setServiceAccessToken(accessToken));
+        assertNotNull(api, "Failed to create an AuthleteApi instance for V3");
+
+        runAuthorizationCodeFlow("V3", api);
+    }
+
+    private static void runAuthorizationCodeFlow(String label, AuthleteApi api) {
+        Client createdClient = null;
+        Throwable failure = null;
+
+        try {
+            String clientName = "sdk-playground-smoke-" + randomAlnum(12);
+            String state = randomAlnum(24);
+
+            System.out.println("[smoke:" + label + "] Step 1: Creating a confidential authorization-code client: " + clientName);
+            Client clientRequest = new Client()
+                    .setClientName(clientName)
+                    .setClientType(ClientType.CONFIDENTIAL)
+                    .setGrantTypes(new GrantType[] { GrantType.AUTHORIZATION_CODE })
+                    .setResponseTypes(new ResponseType[] { ResponseType.CODE })
+                    .setRedirectUris(new String[] { REDIRECT_URI });
+            createdClient = api.createClient(clientRequest);
+            assertNotNull(createdClient, "Created client must not be null");
+            assertTrue(createdClient.getClientId() > 0, "Created client ID must be positive");
+            assertNotNull(createdClient.getClientSecret(), "Created client secret must not be null");
+            assertFalse(createdClient.getClientSecret().isBlank(), "Created client secret must not be blank");
+            System.out.println("[smoke:" + label + "] Step 1 result: clientId=" + createdClient.getClientId());
+
+            System.out.println("[smoke:" + label + "] Step 2: Calling /auth/authorization");
+            String authorizationParameters = "response_type=code"
+                    + "&client_id=" + createdClient.getClientId()
+                    + "&redirect_uri=" + encode(REDIRECT_URI)
+                    + "&state=" + encode(state);
+            AuthorizationRequest authorizationRequest = new AuthorizationRequest()
+                    .setParameters(authorizationParameters);
+            AuthorizationResponse authorizationResponse = api.authorization(authorizationRequest);
+            assertEquals(AuthorizationResponse.Action.INTERACTION, authorizationResponse.getAction(),
+                    "Authorization action must be INTERACTION");
+            assertNotNull(authorizationResponse.getTicket(), "Authorization ticket must not be null");
+            System.out.println("[smoke:" + label + "] Step 2 result: action=" + authorizationResponse.getAction());
+
+            System.out.println("[smoke:" + label + "] Step 3: Issuing authorization response");
+            AuthorizationIssueRequest issueRequest = new AuthorizationIssueRequest()
+                    .setTicket(authorizationResponse.getTicket())
+                    .setSubject(SUBJECT);
+            AuthorizationIssueResponse issueResponse = api.authorizationIssue(issueRequest);
+            assertEquals(AuthorizationIssueResponse.Action.LOCATION, issueResponse.getAction(),
+                    "Authorization issue action must be LOCATION");
+            assertNotNull(issueResponse.getResponseContent(), "Authorization issue response content must not be null");
+            assertTrue(issueResponse.getResponseContent().contains("code="),
+                    "Redirect URL must contain an authorization code");
+            assertTrue(issueResponse.getResponseContent().contains("state=" + state),
+                    "Redirect URL must contain the original state");
+            System.out.println("[smoke:" + label + "] Step 3 result: action=" + issueResponse.getAction());
+
+            String authorizationCode = extractQueryParameter(issueResponse.getResponseContent(), "code");
+            assertNotNull(authorizationCode, "Authorization code must be present in the redirect URL");
+            assertFalse(authorizationCode.isBlank(), "Authorization code must not be blank");
+
+            System.out.println("[smoke:" + label + "] Step 4: Exchanging authorization code for tokens");
+            String tokenParameters = "grant_type=authorization_code"
+                    + "&code=" + encode(authorizationCode)
+                    + "&redirect_uri=" + encode(REDIRECT_URI);
+            TokenRequest tokenRequest = new TokenRequest()
+                    .setParameters(tokenParameters)
+                    .setClientId(String.valueOf(createdClient.getClientId()))
+                    .setClientSecret(createdClient.getClientSecret());
+            TokenResponse tokenResponse = api.token(tokenRequest);
+            assertEquals(TokenResponse.Action.OK, tokenResponse.getAction(), "Token action must be OK");
+            assertNotNull(tokenResponse.getAccessToken(), "Access token must not be null");
+            assertFalse(tokenResponse.getAccessToken().isBlank(), "Access token must not be blank");
+            System.out.println("[smoke:" + label + "] Step 4 result: action=" + tokenResponse.getAction());
+
+            System.out.println("[smoke:" + label + "] Step 5: Introspecting the access token");
+            IntrospectionRequest introspectionRequest = new IntrospectionRequest()
+                    .setToken(tokenResponse.getAccessToken());
+            IntrospectionResponse introspectionResponse = api.introspection(introspectionRequest);
+            assertEquals(IntrospectionResponse.Action.OK, introspectionResponse.getAction(),
+                    "Introspection action must be OK");
+            assertTrue(introspectionResponse.isUsable(), "Introspected access token must be usable");
+            assertEquals(SUBJECT, introspectionResponse.getSubject(),
+                    "Introspected access token must be bound to the test subject");
+            System.out.println("[smoke:" + label + "] Step 5 result: action=" + introspectionResponse.getAction()
+                    + ", subject=" + introspectionResponse.getSubject());
+        } catch (Throwable t) {
+            failure = t;
+        } finally {
+            // Delete the client without masking the original failure. A cleanup
+            // failure is reported as suppressed (or as the failure itself when
+            // the flow succeeded).
+            if (createdClient != null && createdClient.getClientId() > 0) {
+                System.out.println("[smoke:" + label + "] Cleanup: deleting clientId=" + createdClient.getClientId());
+                try {
+                    api.deleteClient(createdClient.getClientId());
+                    System.out.println("[smoke:" + label + "] Cleanup result: client deleted");
+                } catch (RuntimeException e) {
+                    if (failure != null) {
+                        failure.addSuppressed(e);
+                    } else {
+                        failure = e;
+                    }
+                }
+            }
+        }
+
+        if (failure instanceof RuntimeException) {
+            throw (RuntimeException) failure;
+        }
+        if (failure instanceof Error) {
+            throw (Error) failure;
+        }
+        if (failure != null) {
+            throw new RuntimeException(failure);
+        }
+    }
+
+    /**
+     * Returns the value of {@code primaryName}. When it is not set and
+     * {@code fallbackAllowed} is true, returns the value of
+     * {@code fallbackName} instead.
+     */
+    private static String envOrFallback(String primaryName, String fallbackName, boolean fallbackAllowed) {
+        String primary = env(primaryName);
+
+        if (!primary.isBlank() || !fallbackAllowed) {
+            return primary;
+        }
+
+        return env(fallbackName);
+    }
+
+    private static boolean isV3Env() {
+        String version = env("AUTHLETE_API_VERSION");
+        return version.equalsIgnoreCase("3") || version.equalsIgnoreCase("V3");
+    }
+
+    private static String env(String name) {
+        String value = System.getenv(name);
+        return value == null ? "" : value.trim();
+    }
+
+    private static String randomAlnum(int length) {
+        final String alphabet = "abcdefghijklmnopqrstuvwxyz0123456789";
+        StringBuilder builder = new StringBuilder(length);
+
+        for (int i = 0; i < length; i++) {
+            builder.append(alphabet.charAt(RANDOM.nextInt(alphabet.length())));
+        }
+
+        return builder.toString();
+    }
+
+    private static String encode(String value) {
+        return java.net.URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private static String extractQueryParameter(String url, String name) {
+        URI uri = URI.create(url);
+        Map<String, String> queryParameters = parseQuery(uri.getRawQuery());
+        return queryParameters.get(name);
+    }
+
+    private static Map<String, String> parseQuery(String query) {
+        Map<String, String> parameters = new LinkedHashMap<>();
+
+        if (query == null || query.isBlank()) {
+            return parameters;
+        }
+
+        for (String pair : query.split("&")) {
+            String[] elements = pair.split("=", 2);
+            String key = decode(elements[0]);
+            String value = elements.length > 1 ? decode(elements[1]) : "";
+            parameters.put(key, value);
+        }
+
+        return parameters;
+    }
+
+    private static String decode(String value) {
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/java/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
+++ b/java/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
@@ -10,12 +10,14 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import com.authlete.common.api.AuthleteApi;
+import com.authlete.common.api.AuthleteApiException;
 import com.authlete.common.api.AuthleteApiFactory;
 import com.authlete.common.conf.AuthleteSimpleConfiguration;
 import com.authlete.common.dto.AuthorizationIssueRequest;
@@ -48,6 +50,8 @@ public class AuthorizationCodeFlowSmokeTest {
     private static final String SUBJECT = "sdk-playground-user";
     // The V2 /client/create API requires a developer identifier.
     private static final String DEVELOPER = "sdk-playground-developer";
+    // Transient errors (429 and 5xx) are retried with exponential backoff.
+    private static final int MAX_RETRIES = 3;
     private static final SecureRandom RANDOM = new SecureRandom();
 
     @Test
@@ -113,7 +117,7 @@ public class AuthorizationCodeFlowSmokeTest {
                     .setGrantTypes(new GrantType[] { GrantType.AUTHORIZATION_CODE })
                     .setResponseTypes(new ResponseType[] { ResponseType.CODE })
                     .setRedirectUris(new String[] { REDIRECT_URI });
-            createdClient = api.createClient(clientRequest);
+            createdClient = callWithRetry(label, "/client/create", () -> api.createClient(clientRequest));
             assertNotNull(createdClient, "Created client must not be null");
             assertTrue(createdClient.getClientId() > 0, "Created client ID must be positive");
             assertNotNull(createdClient.getClientSecret(), "Created client secret must not be null");
@@ -127,7 +131,8 @@ public class AuthorizationCodeFlowSmokeTest {
                     + "&state=" + encode(state);
             AuthorizationRequest authorizationRequest = new AuthorizationRequest()
                     .setParameters(authorizationParameters);
-            AuthorizationResponse authorizationResponse = api.authorization(authorizationRequest);
+            AuthorizationResponse authorizationResponse =
+                    callWithRetry(label, "/auth/authorization", () -> api.authorization(authorizationRequest));
             assertEquals(AuthorizationResponse.Action.INTERACTION, authorizationResponse.getAction(),
                     "Authorization action must be INTERACTION");
             assertNotNull(authorizationResponse.getTicket(), "Authorization ticket must not be null");
@@ -137,7 +142,8 @@ public class AuthorizationCodeFlowSmokeTest {
             AuthorizationIssueRequest issueRequest = new AuthorizationIssueRequest()
                     .setTicket(authorizationResponse.getTicket())
                     .setSubject(SUBJECT);
-            AuthorizationIssueResponse issueResponse = api.authorizationIssue(issueRequest);
+            AuthorizationIssueResponse issueResponse =
+                    callWithRetry(label, "/auth/authorization/issue", () -> api.authorizationIssue(issueRequest));
             assertEquals(AuthorizationIssueResponse.Action.LOCATION, issueResponse.getAction(),
                     "Authorization issue action must be LOCATION");
             assertNotNull(issueResponse.getResponseContent(), "Authorization issue response content must not be null");
@@ -159,7 +165,7 @@ public class AuthorizationCodeFlowSmokeTest {
                     .setParameters(tokenParameters)
                     .setClientId(String.valueOf(createdClient.getClientId()))
                     .setClientSecret(createdClient.getClientSecret());
-            TokenResponse tokenResponse = api.token(tokenRequest);
+            TokenResponse tokenResponse = callWithRetry(label, "/auth/token", () -> api.token(tokenRequest));
             assertEquals(TokenResponse.Action.OK, tokenResponse.getAction(), "Token action must be OK");
             assertNotNull(tokenResponse.getAccessToken(), "Access token must not be null");
             assertFalse(tokenResponse.getAccessToken().isBlank(), "Access token must not be blank");
@@ -168,7 +174,8 @@ public class AuthorizationCodeFlowSmokeTest {
             System.out.println("[smoke:" + label + "] Step 5: Introspecting the access token");
             IntrospectionRequest introspectionRequest = new IntrospectionRequest()
                     .setToken(tokenResponse.getAccessToken());
-            IntrospectionResponse introspectionResponse = api.introspection(introspectionRequest);
+            IntrospectionResponse introspectionResponse =
+                    callWithRetry(label, "/auth/introspection", () -> api.introspection(introspectionRequest));
             assertEquals(IntrospectionResponse.Action.OK, introspectionResponse.getAction(),
                     "Introspection action must be OK");
             assertTrue(introspectionResponse.isUsable(), "Introspected access token must be usable");
@@ -185,8 +192,12 @@ public class AuthorizationCodeFlowSmokeTest {
             if (createdClient != null && createdClient.getClientId() > 0) {
                 System.out.println("[smoke:" + label + "] Cleanup: deleting clientId=" + createdClient.getClientId());
                 try {
-                    api.deleteClient(createdClient.getClientId());
-                    verifyClientDeleted(api, createdClient.getClientId());
+                    long clientId = createdClient.getClientId();
+                    callWithRetry(label, "/client/delete", () -> {
+                        api.deleteClient(clientId);
+                        return null;
+                    });
+                    verifyClientDeleted(label, api, clientId);
                     System.out.println("[smoke:" + label + "] Cleanup result: client deleted");
                 } catch (RuntimeException e) {
                     if (failure != null) {
@@ -215,9 +226,16 @@ public class AuthorizationCodeFlowSmokeTest {
      * the deletion, which would leak clients and eventually exhaust the
      * service's client quota.
      */
-    private static void verifyClientDeleted(AuthleteApi api, long clientId) {
+    private static void verifyClientDeleted(String label, AuthleteApi api, long clientId) {
         try {
-            api.getClient(clientId);
+            callWithRetry(label, "/client/get (verify deletion)", () -> api.getClient(clientId));
+        } catch (AuthleteApiException e) {
+            if (isRetryableStatus(e.getStatusCode())) {
+                throw new IllegalStateException(
+                        "Could not verify the deletion of client " + clientId, e);
+            }
+            // Expected: the client no longer exists.
+            return;
         } catch (RuntimeException e) {
             // Expected: the client no longer exists.
             return;
@@ -225,6 +243,78 @@ public class AuthorizationCodeFlowSmokeTest {
 
         throw new IllegalStateException(
                 "Client " + clientId + " still exists after deleteClient()");
+    }
+
+    @FunctionalInterface
+    private interface ApiCall<T> {
+        T call();
+    }
+
+    /**
+     * Executes an Authlete API call, retrying transient errors (429 and 5xx)
+     * following https://www.authlete.com/kb/deployment/performance/ratelimit-best-practices/:
+     * honor the Ratelimit-Reset header when present, otherwise use exponential
+     * backoff (500 ms, 1 s, 2 s) with a small random jitter.
+     */
+    private static <T> T callWithRetry(String label, String api, ApiCall<T> call) {
+        for (int attempt = 0; ; attempt++) {
+            try {
+                return call.call();
+            } catch (AuthleteApiException e) {
+                if (attempt >= MAX_RETRIES || !isRetryableStatus(e.getStatusCode())) {
+                    throw e;
+                }
+
+                long delayMillis = retryDelayMillis(attempt, e.getResponseHeaders());
+                System.out.println("[smoke:" + label + "] " + api + " failed with HTTP " + e.getStatusCode()
+                        + "; retrying in " + delayMillis + " ms (attempt " + (attempt + 1) + "/" + MAX_RETRIES + ")");
+                sleep(delayMillis);
+            }
+        }
+    }
+
+    private static boolean isRetryableStatus(int statusCode) {
+        return statusCode == 429 || statusCode >= 500;
+    }
+
+    private static long retryDelayMillis(int attempt, Map<String, List<String>> headers) {
+        long resetSeconds = ratelimitResetSeconds(headers);
+
+        if (resetSeconds > 0) {
+            return Math.min(resetSeconds, 30) * 1000L;
+        }
+
+        return (500L << attempt) + RANDOM.nextInt(250);
+    }
+
+    private static long ratelimitResetSeconds(Map<String, List<String>> headers) {
+        if (headers == null) {
+            return 0;
+        }
+
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            if (entry.getKey() == null || !entry.getKey().equalsIgnoreCase("Ratelimit-Reset")
+                    || entry.getValue() == null || entry.getValue().isEmpty()) {
+                continue;
+            }
+
+            try {
+                return Long.parseLong(entry.getValue().get(0).trim());
+            } catch (NumberFormatException e) {
+                return 0;
+            }
+        }
+
+        return 0;
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting to retry", e);
+        }
     }
 
     /**

--- a/java/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
+++ b/java/src/test/java/com/authlete/sdklab/AuthorizationCodeFlowSmokeTest.java
@@ -46,6 +46,8 @@ import com.authlete.common.types.ResponseType;
 public class AuthorizationCodeFlowSmokeTest {
     private static final String REDIRECT_URI = "https://sdk-playground.example.com/callback";
     private static final String SUBJECT = "sdk-playground-user";
+    // The V2 /client/create API requires a developer identifier.
+    private static final String DEVELOPER = "sdk-playground-developer";
     private static final SecureRandom RANDOM = new SecureRandom();
 
     @Test
@@ -58,11 +60,18 @@ public class AuthorizationCodeFlowSmokeTest {
                 "Skipping V2 smoke test: AUTHLETE_V2_BASE_URL, AUTHLETE_V2_SERVICE_APIKEY and"
                         + " AUTHLETE_V2_SERVICE_APISECRET (or plain AUTHLETE_* V2 credentials) are not set");
 
+        // The service-owner credentials are set to the service credentials on
+        // purpose: authlete-java-common's HttpURLConnection-based V2
+        // implementation (4.47) sends /api/client/delete with the
+        // service-owner credentials, and the server also accepts the service
+        // credentials there.
         AuthleteApi api = AuthleteApiFactory.create(new AuthleteSimpleConfiguration()
                 .setApiVersion("V2")
                 .setBaseUrl(baseUrl)
                 .setServiceApiKey(apiKey)
-                .setServiceApiSecret(apiSecret));
+                .setServiceApiSecret(apiSecret)
+                .setServiceOwnerApiKey(apiKey)
+                .setServiceOwnerApiSecret(apiSecret));
         assertNotNull(api, "Failed to create an AuthleteApi instance for V2");
 
         runAuthorizationCodeFlow("V2", api);
@@ -99,6 +108,7 @@ public class AuthorizationCodeFlowSmokeTest {
             System.out.println("[smoke:" + label + "] Step 1: Creating a confidential authorization-code client: " + clientName);
             Client clientRequest = new Client()
                     .setClientName(clientName)
+                    .setDeveloper(DEVELOPER)
                     .setClientType(ClientType.CONFIDENTIAL)
                     .setGrantTypes(new GrantType[] { GrantType.AUTHORIZATION_CODE })
                     .setResponseTypes(new ResponseType[] { ResponseType.CODE })
@@ -176,6 +186,7 @@ public class AuthorizationCodeFlowSmokeTest {
                 System.out.println("[smoke:" + label + "] Cleanup: deleting clientId=" + createdClient.getClientId());
                 try {
                     api.deleteClient(createdClient.getClientId());
+                    verifyClientDeleted(api, createdClient.getClientId());
                     System.out.println("[smoke:" + label + "] Cleanup result: client deleted");
                 } catch (RuntimeException e) {
                     if (failure != null) {
@@ -196,6 +207,24 @@ public class AuthorizationCodeFlowSmokeTest {
         if (failure != null) {
             throw new RuntimeException(failure);
         }
+    }
+
+    /**
+     * Ensures that the client has actually been deleted. Some SDK versions
+     * report success from {@code deleteClient} even when the server rejected
+     * the deletion, which would leak clients and eventually exhaust the
+     * service's client quota.
+     */
+    private static void verifyClientDeleted(AuthleteApi api, long clientId) {
+        try {
+            api.getClient(clientId);
+        } catch (RuntimeException e) {
+            // Expected: the client no longer exists.
+            return;
+        }
+
+        throw new IllegalStateException(
+                "Client " + clientId + " still exists after deleteClient()");
     }
 
     /**

--- a/php/composer.json
+++ b/php/composer.json
@@ -11,6 +11,9 @@
       "Authlete\\SdkLab\\": "src/"
     }
   },
+  "scripts": {
+    "test": "php tests/authorization_code_flow_test.php"
+  },
   "config": {
     "sort-packages": true
   }

--- a/php/tests/authorization_code_flow_test.php
+++ b/php/tests/authorization_code_flow_test.php
@@ -27,6 +27,8 @@ use Authlete\Types\ResponseType;
 
 const REDIRECT_URI = 'https://sdk-playground.example.com/callback';
 const SUBJECT      = 'sdk-playground-user';
+// The V2 /client/create API requires a developer identifier.
+const DEVELOPER    = 'sdk-playground-developer';
 
 function assertThat(bool $condition, string $message): void
 {
@@ -88,6 +90,7 @@ try
     $created = $api->createClient(
         (new Client())
             ->setClientName($clientName)
+            ->setDeveloper(DEVELOPER)
             ->setClientType(ClientType::$CONFIDENTIAL)
             ->setGrantTypes([GrantType::$AUTHORIZATION_CODE])
             ->setResponseTypes([ResponseType::$CODE])
@@ -175,9 +178,19 @@ try
 }
 catch (Throwable $e)
 {
-    // exit() would skip the finally block, so only record the failure here.
-    fwrite(STDERR, 'FAIL: ' . $e->getMessage() . "\n");
-    $exitCode = 1;
+    if (str_contains($e->getMessage(), 'cannot be parsed as Authlete\\Types\\'))
+    {
+        // Known limitation of authlete/authlete 1.x: it cannot parse newer
+        // grant/response types (e.g. TOKEN_EXCHANGE, JWT_BEARER) that the
+        // service may support, which makes API responses unparseable.
+        echo 'SKIP: known SDK limitation: ' . $e->getMessage() . "\n";
+    }
+    else
+    {
+        // exit() would skip the finally block, so only record the failure here.
+        fwrite(STDERR, 'FAIL: ' . $e->getMessage() . "\n");
+        $exitCode = 1;
+    }
 }
 finally
 {

--- a/php/tests/authorization_code_flow_test.php
+++ b/php/tests/authorization_code_flow_test.php
@@ -10,6 +10,7 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
+use Authlete\Api\AuthleteApiException;
 use Authlete\Api\AuthleteApiImpl;
 use Authlete\Conf\AuthleteSimpleConfiguration;
 use Authlete\Dto\AuthorizationAction;
@@ -29,6 +30,8 @@ const REDIRECT_URI = 'https://sdk-playground.example.com/callback';
 const SUBJECT      = 'sdk-playground-user';
 // The V2 /client/create API requires a developer identifier.
 const DEVELOPER    = 'sdk-playground-developer';
+// Transient errors (429 and 5xx) are retried with exponential backoff.
+const MAX_RETRIES  = 3;
 
 function assertThat(bool $condition, string $message): void
 {
@@ -36,6 +39,56 @@ function assertThat(bool $condition, string $message): void
     {
         throw new RuntimeException($message);
     }
+}
+
+/**
+ * Executes an Authlete API call, retrying transient errors (429 and 5xx)
+ * following https://www.authlete.com/kb/deployment/performance/ratelimit-best-practices/:
+ * honor the Ratelimit-Reset header when present, otherwise use exponential
+ * backoff (500 ms, 1 s, 2 s) with a small random jitter.
+ */
+function callWithRetry(string $label, callable $call)
+{
+    for ($attempt = 0; ; $attempt++)
+    {
+        try
+        {
+            return $call();
+        }
+        catch (AuthleteApiException $e)
+        {
+            $status = $e->getStatusCode();
+            if ($attempt >= MAX_RETRIES || !($status === 429 || $status >= 500))
+            {
+                throw $e;
+            }
+
+            $delayMs = retryDelayMillis($attempt, $e->getResponseHeaders());
+            echo "      {$label} failed with HTTP {$status}; retrying in {$delayMs} ms"
+                . ' (attempt ' . ($attempt + 1) . '/' . MAX_RETRIES . ")\n";
+            usleep($delayMs * 1000);
+        }
+    }
+}
+
+function retryDelayMillis(int $attempt, ?array $headers): int
+{
+    foreach (($headers ?? []) as $name => $values)
+    {
+        if (strcasecmp((string)$name, 'Ratelimit-Reset') !== 0)
+        {
+            continue;
+        }
+
+        $value   = is_array($values) ? (string)($values[0] ?? '') : (string)$values;
+        $seconds = (int)trim($value);
+        if ($seconds > 0)
+        {
+            return min($seconds, 30) * 1000;
+        }
+    }
+
+    return (500 << $attempt) + random_int(0, 250);
 }
 
 function queryValue(string $url, string $key): ?string
@@ -87,7 +140,7 @@ try
     $clientName = 'sdk-playground-smoke-' . bin2hex(random_bytes(6));
     echo "[1/6] Creating test client: {$clientName}\n";
 
-    $created = $api->createClient(
+    $created = callWithRetry('/client/create', fn() => $api->createClient(
         (new Client())
             ->setClientName($clientName)
             ->setDeveloper(DEVELOPER)
@@ -95,7 +148,7 @@ try
             ->setGrantTypes([GrantType::$AUTHORIZATION_CODE])
             ->setResponseTypes([ResponseType::$CODE])
             ->setRedirectUris([REDIRECT_URI])
-    );
+    ));
     assertThat($created->getClientId() > 0, '/client/create returned no clientId');
     assertThat((string)$created->getClientSecret() !== '', '/client/create returned no clientSecret');
     echo '      clientId=' . $created->getClientId() . "\n";
@@ -104,7 +157,7 @@ try
     $state = bin2hex(random_bytes(8));
     echo "[2/6] Calling /auth/authorization\n";
 
-    $authzResponse = $api->authorization(
+    $authzResponse = callWithRetry('/auth/authorization', fn() => $api->authorization(
         (new AuthorizationRequest())
             ->setParameters(http_build_query([
                 'response_type' => 'code',
@@ -112,7 +165,7 @@ try
                 'redirect_uri'  => REDIRECT_URI,
                 'state'         => $state,
             ]))
-    );
+    ));
     assertThat(
         $authzResponse->getAction() === AuthorizationAction::$INTERACTION,
         'expected action INTERACTION, got ' . var_export($authzResponse->getAction(), true)
@@ -123,11 +176,11 @@ try
     // Step 3: /auth/authorization/issue
     echo "[3/6] Calling /auth/authorization/issue\n";
 
-    $issueResponse = $api->authorizationIssue(
+    $issueResponse = callWithRetry('/auth/authorization/issue', fn() => $api->authorizationIssue(
         (new AuthorizationIssueRequest())
             ->setTicket($authzResponse->getTicket())
             ->setSubject(SUBJECT)
-    );
+    ));
     assertThat(
         $issueResponse->getAction() === AuthorizationIssueAction::$LOCATION,
         'expected action LOCATION, got ' . var_export($issueResponse->getAction(), true)
@@ -142,7 +195,7 @@ try
     // Step 4: /auth/token
     echo "[4/6] Calling /auth/token\n";
 
-    $tokenResponse = $api->token(
+    $tokenResponse = callWithRetry('/auth/token', fn() => $api->token(
         (new TokenRequest())
             ->setParameters(http_build_query([
                 'grant_type'   => 'authorization_code',
@@ -151,7 +204,7 @@ try
             ]))
             ->setClientId((string)$created->getClientId())
             ->setClientSecret($created->getClientSecret())
-    );
+    ));
     assertThat(
         $tokenResponse->getAction() === TokenAction::$OK,
         'expected action OK, got ' . var_export($tokenResponse->getAction(), true)
@@ -163,9 +216,9 @@ try
     // Step 5: /auth/introspection
     echo "[5/6] Calling /auth/introspection\n";
 
-    $introspectionResponse = $api->introspection(
+    $introspectionResponse = callWithRetry('/auth/introspection', fn() => $api->introspection(
         (new IntrospectionRequest())->setToken($accessToken)
-    );
+    ));
     assertThat(
         $introspectionResponse->getAction() === IntrospectionAction::$OK,
         'expected action OK, got ' . var_export($introspectionResponse->getAction(), true)
@@ -201,7 +254,7 @@ finally
         echo '[6/6] Deleting test client: ' . $created->getClientId() . "\n";
         try
         {
-            $api->deleteClient($created->getClientId());
+            callWithRetry('/client/delete', fn() => $api->deleteClient($created->getClientId()));
         }
         catch (Throwable $e)
         {

--- a/php/tests/authorization_code_flow_test.php
+++ b/php/tests/authorization_code_flow_test.php
@@ -1,0 +1,184 @@
+<?php
+//
+// Smoke test that runs a minimal OAuth 2.0 authorization code flow against
+// the Authlete V2 API: create client -> /auth/authorization ->
+// /auth/authorization/issue -> /auth/token -> /auth/introspection -> delete client.
+//
+// Usage: php tests/authorization_code_flow_test.php
+// Exits with 0 on success or skip, 1 on failure.
+//
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Authlete\Api\AuthleteApiImpl;
+use Authlete\Conf\AuthleteEnvConfiguration;
+use Authlete\Dto\AuthorizationAction;
+use Authlete\Dto\AuthorizationIssueAction;
+use Authlete\Dto\AuthorizationIssueRequest;
+use Authlete\Dto\AuthorizationRequest;
+use Authlete\Dto\Client;
+use Authlete\Dto\IntrospectionAction;
+use Authlete\Dto\IntrospectionRequest;
+use Authlete\Dto\TokenAction;
+use Authlete\Dto\TokenRequest;
+use Authlete\Types\ClientType;
+use Authlete\Types\GrantType;
+use Authlete\Types\ResponseType;
+
+const REDIRECT_URI = 'https://sdk-playground.example.com/callback';
+const SUBJECT      = 'sdk-playground-user';
+
+function assertThat(bool $condition, string $message): void
+{
+    if (!$condition)
+    {
+        throw new RuntimeException($message);
+    }
+}
+
+function queryValue(string $url, string $key): ?string
+{
+    parse_str((string)parse_url($url, PHP_URL_QUERY), $params);
+
+    return isset($params[$key]) ? (string)$params[$key] : null;
+}
+
+$apiVersion = (string)getenv('AUTHLETE_API_VERSION');
+if (in_array(strtoupper($apiVersion), ['3', 'V3'], true))
+{
+    echo "SKIP: authlete/authlete supports only the Authlete V2 API\n";
+    exit(0);
+}
+
+$required = ['AUTHLETE_BASE_URL', 'AUTHLETE_SERVICE_APIKEY', 'AUTHLETE_SERVICE_APISECRET'];
+$missing  = array_values(array_filter($required, fn($key) => (string)getenv($key) === ''));
+if (count($missing) > 0)
+{
+    echo 'SKIP: missing Authlete env vars: ' . implode(', ', $missing) . "\n";
+    exit(0);
+}
+
+$api      = new AuthleteApiImpl(new AuthleteEnvConfiguration());
+$created  = null;
+$exitCode = 0;
+
+try
+{
+    // Step 1: create a disposable client for this test.
+    $clientName = 'sdk-playground-smoke-' . bin2hex(random_bytes(6));
+    echo "[1/6] Creating test client: {$clientName}\n";
+
+    $created = $api->createClient(
+        (new Client())
+            ->setClientName($clientName)
+            ->setClientType(ClientType::$CONFIDENTIAL)
+            ->setGrantTypes([GrantType::$AUTHORIZATION_CODE])
+            ->setResponseTypes([ResponseType::$CODE])
+            ->setRedirectUris([REDIRECT_URI])
+    );
+    assertThat($created->getClientId() > 0, '/client/create returned no clientId');
+    assertThat((string)$created->getClientSecret() !== '', '/client/create returned no clientSecret');
+    echo '      clientId=' . $created->getClientId() . "\n";
+
+    // Step 2: /auth/authorization
+    $state = bin2hex(random_bytes(8));
+    echo "[2/6] Calling /auth/authorization\n";
+
+    $authzResponse = $api->authorization(
+        (new AuthorizationRequest())
+            ->setParameters(http_build_query([
+                'response_type' => 'code',
+                'client_id'     => (string)$created->getClientId(),
+                'redirect_uri'  => REDIRECT_URI,
+                'state'         => $state,
+            ]))
+    );
+    assertThat(
+        $authzResponse->getAction() === AuthorizationAction::$INTERACTION,
+        'expected action INTERACTION, got ' . var_export($authzResponse->getAction(), true)
+    );
+    assertThat((string)$authzResponse->getTicket() !== '', 'authorization ticket must be present');
+    echo "      action=INTERACTION ticket issued\n";
+
+    // Step 3: /auth/authorization/issue
+    echo "[3/6] Calling /auth/authorization/issue\n";
+
+    $issueResponse = $api->authorizationIssue(
+        (new AuthorizationIssueRequest())
+            ->setTicket($authzResponse->getTicket())
+            ->setSubject(SUBJECT)
+    );
+    assertThat(
+        $issueResponse->getAction() === AuthorizationIssueAction::$LOCATION,
+        'expected action LOCATION, got ' . var_export($issueResponse->getAction(), true)
+    );
+    $location = (string)$issueResponse->getResponseContent();
+    assertThat(str_contains($location, 'code='), "no authorization code in: {$location}");
+    assertThat(queryValue($location, 'state') === $state, 'state mismatch in redirect URL');
+    $code = (string)queryValue($location, 'code');
+    assertThat($code !== '', 'authorization code must be present');
+    echo "      action=LOCATION authorization code issued\n";
+
+    // Step 4: /auth/token
+    echo "[4/6] Calling /auth/token\n";
+
+    $tokenResponse = $api->token(
+        (new TokenRequest())
+            ->setParameters(http_build_query([
+                'grant_type'   => 'authorization_code',
+                'code'         => $code,
+                'redirect_uri' => REDIRECT_URI,
+            ]))
+            ->setClientId((string)$created->getClientId())
+            ->setClientSecret($created->getClientSecret())
+    );
+    assertThat(
+        $tokenResponse->getAction() === TokenAction::$OK,
+        'expected action OK, got ' . var_export($tokenResponse->getAction(), true)
+    );
+    $accessToken = (string)$tokenResponse->getAccessToken();
+    assertThat($accessToken !== '', 'access token must be present');
+    echo "      action=OK access token issued\n";
+
+    // Step 5: /auth/introspection
+    echo "[5/6] Calling /auth/introspection\n";
+
+    $introspectionResponse = $api->introspection(
+        (new IntrospectionRequest())->setToken($accessToken)
+    );
+    assertThat(
+        $introspectionResponse->getAction() === IntrospectionAction::$OK,
+        'expected action OK, got ' . var_export($introspectionResponse->getAction(), true)
+    );
+    assertThat($introspectionResponse->isUsable() === true, 'introspected access token must be usable');
+    assertThat($introspectionResponse->getSubject() === SUBJECT, 'access token must be bound to the test subject');
+    echo "      action=OK access token is valid\n";
+
+    echo "PASS: authorization code flow completed successfully\n";
+}
+catch (Throwable $e)
+{
+    // exit() would skip the finally block, so only record the failure here.
+    fwrite(STDERR, 'FAIL: ' . $e->getMessage() . "\n");
+    $exitCode = 1;
+}
+finally
+{
+    // Step 6: always delete the disposable client. A cleanup failure fails the
+    // test but must not hide an earlier failure.
+    if ($created !== null && $created->getClientId() > 0)
+    {
+        echo '[6/6] Deleting test client: ' . $created->getClientId() . "\n";
+        try
+        {
+            $api->deleteClient($created->getClientId());
+        }
+        catch (Throwable $e)
+        {
+            fwrite(STDERR, 'WARNING: failed to delete test client: ' . $e->getMessage() . "\n");
+            $exitCode = 1;
+        }
+    }
+}
+
+exit($exitCode);

--- a/php/tests/authorization_code_flow_test.php
+++ b/php/tests/authorization_code_flow_test.php
@@ -11,7 +11,7 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 use Authlete\Api\AuthleteApiImpl;
-use Authlete\Conf\AuthleteEnvConfiguration;
+use Authlete\Conf\AuthleteSimpleConfiguration;
 use Authlete\Dto\AuthorizationAction;
 use Authlete\Dto\AuthorizationIssueAction;
 use Authlete\Dto\AuthorizationIssueRequest;
@@ -43,22 +43,39 @@ function queryValue(string $url, string $key): ?string
     return isset($params[$key]) ? (string)$params[$key] : null;
 }
 
-$apiVersion = (string)getenv('AUTHLETE_API_VERSION');
-if (in_array(strtoupper($apiVersion), ['3', 'V3'], true))
+// Prefer the version-specific AUTHLETE_V2_* variables; fall back to the
+// plain AUTHLETE_* variables when they hold a V2 configuration.
+$baseUrl   = (string)getenv('AUTHLETE_V2_BASE_URL');
+$apiKey    = (string)getenv('AUTHLETE_V2_SERVICE_APIKEY');
+$apiSecret = (string)getenv('AUTHLETE_V2_SERVICE_APISECRET');
+
+if ($baseUrl === '' && $apiKey === '' && $apiSecret === '')
 {
-    echo "SKIP: authlete/authlete supports only the Authlete V2 API\n";
+    $apiVersion = strtoupper((string)getenv('AUTHLETE_API_VERSION'));
+    if (in_array($apiVersion, ['3', 'V3'], true))
+    {
+        echo "SKIP: authlete/authlete supports only the Authlete V2 API\n";
+        exit(0);
+    }
+
+    $baseUrl   = (string)getenv('AUTHLETE_BASE_URL');
+    $apiKey    = (string)getenv('AUTHLETE_SERVICE_APIKEY');
+    $apiSecret = (string)getenv('AUTHLETE_SERVICE_APISECRET');
+}
+
+if ($baseUrl === '' || $apiKey === '' || $apiSecret === '')
+{
+    echo "SKIP: AUTHLETE_V2_BASE_URL, AUTHLETE_V2_SERVICE_APIKEY and AUTHLETE_V2_SERVICE_APISECRET"
+        . " (or plain AUTHLETE_* V2 credentials) are required\n";
     exit(0);
 }
 
-$required = ['AUTHLETE_BASE_URL', 'AUTHLETE_SERVICE_APIKEY', 'AUTHLETE_SERVICE_APISECRET'];
-$missing  = array_values(array_filter($required, fn($key) => (string)getenv($key) === ''));
-if (count($missing) > 0)
-{
-    echo 'SKIP: missing Authlete env vars: ' . implode(', ', $missing) . "\n";
-    exit(0);
-}
+$conf = new AuthleteSimpleConfiguration();
+$conf->setBaseUrl($baseUrl);
+$conf->setServiceApiKey($apiKey);
+$conf->setServiceApiSecret($apiSecret);
 
-$api      = new AuthleteApiImpl(new AuthleteEnvConfiguration());
+$api      = new AuthleteApiImpl($conf);
 $created  = null;
 $exitCode = 0;
 

--- a/ruby-v2/Dockerfile
+++ b/ruby-v2/Dockerfile
@@ -6,17 +6,21 @@ RUN apt-get update \
        curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Pre-install gems for faster container startup (run as root to write to system gem path)
-COPY Gemfile /tmp/Gemfile
+# Pre-install gems for faster container startup (run as root to write to system gem path).
+# The lockfile is included so the baked gems match it exactly and a later
+# `bundle install` does not need to write to the system gem path.
+COPY Gemfile Gemfile.lock /tmp/
 RUN cd /tmp && bundle install
 
-# Create a non-root user similar to other language samples
+# Create a non-root user similar to other language samples.
+# Permissions (not ownership) open up the gem path so the user keeps write
+# access even when the dev container remaps its UID (e.g. on CI runners).
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash --create-home $USERNAME \
-    && chown -R $USER_UID:$USER_GID /usr/local/bundle
+    && chmod -R a+rwX /usr/local/bundle
 
 USER $USERNAME
 WORKDIR /workspaces/ruby-v2

--- a/ruby-v2/Gemfile
+++ b/ruby-v2/Gemfile
@@ -4,4 +4,5 @@ source 'https://rubygems.org'
 ruby '>= 3.4'
 
 gem 'authlete'
+gem 'minitest', '~> 5.25'  # 6.x depends on prism, which needs a compiler missing from this image
 gem 'rack'  # authlete/api.rb requires rack, but authlete.gemspec doesn't declare it

--- a/ruby-v2/Gemfile.lock
+++ b/ruby-v2/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2026.0224)
+    minitest (5.27.0)
     netrc (0.11.0)
     rack (3.2.5)
     rest-client (2.1.0)
@@ -26,6 +27,7 @@ PLATFORMS
 
 DEPENDENCIES
   authlete
+  minitest (~> 5.25)
   rack
 
 RUBY VERSION

--- a/ruby-v2/test/authorization_code_flow_test.rb
+++ b/ruby-v2/test/authorization_code_flow_test.rb
@@ -10,12 +10,12 @@ class AuthorizationCodeFlowTest < Minitest::Test
   SUBJECT = 'sdk-playground-user'
 
   def test_authorization_code_flow
-    skip_unless_authlete_configured!
+    base_url, api_key, api_secret = resolve_v2_credentials!
 
     api = Authlete::Api.new(
-      host: ENV.fetch('AUTHLETE_BASE_URL', 'https://api.authlete.com'),
-      service_api_key: ENV.fetch('AUTHLETE_SERVICE_APIKEY'),
-      service_api_secret: ENV.fetch('AUTHLETE_SERVICE_APISECRET')
+      host: base_url,
+      service_api_key: api_key,
+      service_api_secret: api_secret
     )
 
     client = nil
@@ -118,17 +118,28 @@ class AuthorizationCodeFlowTest < Minitest::Test
 
   private
 
-  def skip_unless_authlete_configured!
-    base_url = ENV['AUTHLETE_BASE_URL'].to_s.strip
-    api_key = ENV['AUTHLETE_SERVICE_APIKEY'].to_s.strip
-    api_secret = ENV['AUTHLETE_SERVICE_APISECRET'].to_s.strip
-    api_version = ENV['AUTHLETE_API_VERSION'].to_s.strip
+  # Prefer the version-specific AUTHLETE_V2_* variables; fall back to the
+  # plain AUTHLETE_* variables when they hold a V2 configuration.
+  def resolve_v2_credentials!
+    base_url = ENV['AUTHLETE_V2_BASE_URL'].to_s.strip
+    api_key = ENV['AUTHLETE_V2_SERVICE_APIKEY'].to_s.strip
+    api_secret = ENV['AUTHLETE_V2_SERVICE_APISECRET'].to_s.strip
 
-    if base_url.empty? || api_key.empty? || api_secret.empty?
-      skip 'Skipping Authlete smoke test because required environment variables are not set'
+    if base_url.empty? && api_key.empty? && api_secret.empty?
+      api_version = ENV['AUTHLETE_API_VERSION'].to_s.strip
+      skip 'Skipping Authlete smoke test because authlete gem is V2-only' if %w[3 V3].include?(api_version.upcase)
+
+      base_url = ENV['AUTHLETE_BASE_URL'].to_s.strip
+      api_key = ENV['AUTHLETE_SERVICE_APIKEY'].to_s.strip
+      api_secret = ENV['AUTHLETE_SERVICE_APISECRET'].to_s.strip
     end
 
-    skip 'Skipping Authlete smoke test because authlete gem is V2-only' if %w[3 V3].include?(api_version.upcase)
+    if base_url.empty? || api_key.empty? || api_secret.empty?
+      skip 'AUTHLETE_V2_BASE_URL, AUTHLETE_V2_SERVICE_APIKEY and AUTHLETE_V2_SERVICE_APISECRET ' \
+           '(or plain AUTHLETE_* V2 credentials) are required'
+    end
+
+    [base_url, api_key, api_secret]
   end
 
   def random_alnum(length)

--- a/ruby-v2/test/authorization_code_flow_test.rb
+++ b/ruby-v2/test/authorization_code_flow_test.rb
@@ -1,0 +1,162 @@
+require 'cgi'
+require 'minitest/autorun'
+require 'securerandom'
+require 'uri'
+
+require 'authlete'
+
+class AuthorizationCodeFlowTest < Minitest::Test
+  REDIRECT_URI = 'https://sdk-playground.example.com/callback'
+  SUBJECT = 'sdk-playground-user'
+
+  def test_authorization_code_flow
+    skip_unless_authlete_configured!
+
+    api = Authlete::Api.new(
+      host: ENV.fetch('AUTHLETE_BASE_URL', 'https://api.authlete.com'),
+      service_api_key: ENV.fetch('AUTHLETE_SERVICE_APIKEY'),
+      service_api_secret: ENV.fetch('AUTHLETE_SERVICE_APISECRET')
+    )
+
+    client = nil
+
+    begin
+      client_name = "sdk-playground-smoke-#{random_alnum(12)}"
+      state = random_alnum(24)
+
+      puts "[smoke] Step 1: creating client #{client_name}"
+      client = api.client_create(
+        Authlete::Model::Client.new(
+          clientName: client_name,
+          clientType: 'CONFIDENTIAL',
+          grantTypes: ['AUTHORIZATION_CODE'],
+          responseTypes: ['CODE'],
+          redirectUris: [REDIRECT_URI]
+        )
+      )
+
+      client_id = read_field(client, :client_id, :clientId)
+      client_secret = read_field(client, :client_secret, :clientSecret)
+      refute_nil client_id
+      refute_equal 0, client_id.to_i
+      refute_empty client_secret.to_s
+      puts "[smoke] Step 1 result: clientId=#{client_id}"
+
+      authorization_parameters = [
+        'response_type=code',
+        "client_id=#{CGI.escape(client_id.to_s)}",
+        "redirect_uri=#{CGI.escape(REDIRECT_URI)}",
+        "state=#{CGI.escape(state)}"
+      ].join('&')
+
+      puts '[smoke] Step 2: calling /auth/authorization'
+      authorization_response = api.authorization(parameters: authorization_parameters)
+      assert_equal 'INTERACTION', read_field(authorization_response, :action)
+
+      ticket = read_field(authorization_response, :ticket)
+      refute_empty ticket.to_s
+      puts '[smoke] Step 2 result: action=INTERACTION, ticket issued'
+
+      puts '[smoke] Step 3: calling /auth/authorization/issue'
+      issue_response = api.authorization_issue(ticket: ticket, subject: SUBJECT)
+      assert_equal 'LOCATION', read_field(issue_response, :action)
+
+      redirect_location = read_field(issue_response, :response_content, :responseContent)
+      assert_includes redirect_location, 'code='
+      assert_includes redirect_location, "state=#{state}"
+      puts '[smoke] Step 3 result: action=LOCATION, authorization code issued'
+
+      authorization_code = extract_query_parameter(redirect_location, 'code')
+      refute_empty authorization_code.to_s
+      puts '[smoke] Extracted authorization code'
+
+      token_parameters = [
+        'grant_type=authorization_code',
+        "code=#{CGI.escape(authorization_code)}",
+        "redirect_uri=#{CGI.escape(REDIRECT_URI)}"
+      ].join('&')
+
+      puts '[smoke] Step 4: calling /auth/token'
+      token_response = api.token(
+        parameters: token_parameters,
+        clientId: client_id.to_s,
+        clientSecret: client_secret
+      )
+      assert_equal 'OK', read_field(token_response, :action)
+
+      access_token = read_field(token_response, :access_token, :accessToken)
+      refute_empty access_token.to_s
+      puts "[smoke] Step 4 result: accessTokenLength=#{access_token.length}"
+
+      puts '[smoke] Step 5: calling /auth/introspection'
+      introspection_response = api.introspection(token: access_token)
+      assert_equal 'OK', read_field(introspection_response, :action)
+      assert_equal true, read_field(introspection_response, :usable),
+                   'introspected access token must be usable'
+      assert_equal SUBJECT, read_field(introspection_response, :subject),
+                   'access token must be bound to the test subject'
+      puts "[smoke] Step 5 result: subject=#{read_field(introspection_response, :subject).inspect}"
+    ensure
+      flow_error = $! # exception currently propagating out of the begin block, if any
+      if client
+        client_id = read_field(client, :client_id, :clientId)
+
+        unless client_id.to_i.zero?
+          puts "[smoke] Cleanup: deleting clientId=#{client_id}"
+          begin
+            api.client_delete(client_id)
+            puts '[smoke] Cleanup result: client deleted'
+          rescue StandardError => e
+            # Fail the test when cleanup breaks, but never mask an earlier failure.
+            raise if flow_error.nil?
+            puts "[smoke] WARNING: failed to delete test client: #{e.message}"
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  def skip_unless_authlete_configured!
+    base_url = ENV['AUTHLETE_BASE_URL'].to_s.strip
+    api_key = ENV['AUTHLETE_SERVICE_APIKEY'].to_s.strip
+    api_secret = ENV['AUTHLETE_SERVICE_APISECRET'].to_s.strip
+    api_version = ENV['AUTHLETE_API_VERSION'].to_s.strip
+
+    if base_url.empty? || api_key.empty? || api_secret.empty?
+      skip 'Skipping Authlete smoke test because required environment variables are not set'
+    end
+
+    skip 'Skipping Authlete smoke test because authlete gem is V2-only' if %w[3 V3].include?(api_version.upcase)
+  end
+
+  def random_alnum(length)
+    alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789'
+    Array.new(length) { alphabet[SecureRandom.random_number(alphabet.length)] }.join
+  end
+
+  def read_field(object, *names)
+    names.each do |name|
+      return object.public_send(name) if object.respond_to?(name)
+    end
+
+    names.each do |name|
+      ivar = :"@#{name}"
+      return object.instance_variable_get(ivar) if object.instance_variable_defined?(ivar)
+    end
+
+    nil
+  end
+
+  def extract_query_parameter(url, name)
+    uri = URI.parse(url)
+    query = uri.query.to_s
+    pairs = URI.decode_www_form(query)
+    pairs.each do |key, value|
+      return value if key == name
+    end
+
+    nil
+  end
+end

--- a/ruby-v2/test/authorization_code_flow_test.rb
+++ b/ruby-v2/test/authorization_code_flow_test.rb
@@ -8,6 +8,8 @@ require 'authlete'
 class AuthorizationCodeFlowTest < Minitest::Test
   REDIRECT_URI = 'https://sdk-playground.example.com/callback'
   SUBJECT = 'sdk-playground-user'
+  # Transient errors (429 and 5xx) are retried with exponential backoff.
+  MAX_RETRIES = 3
 
   def test_authorization_code_flow
     base_url, api_key, api_secret = resolve_v2_credentials!
@@ -25,16 +27,18 @@ class AuthorizationCodeFlowTest < Minitest::Test
       state = random_alnum(24)
 
       puts "[smoke] Step 1: creating client #{client_name}"
-      client = api.client_create(
-        Authlete::Model::Client.new(
-          clientName: client_name,
-          developer: 'sdk-playground-developer', # required by the V2 /client/create API
-          clientType: 'CONFIDENTIAL',
-          grantTypes: ['AUTHORIZATION_CODE'],
-          responseTypes: ['CODE'],
-          redirectUris: [REDIRECT_URI]
+      client = call_with_retry('/client/create') do
+        api.client_create(
+          Authlete::Model::Client.new(
+            clientName: client_name,
+            developer: 'sdk-playground-developer', # required by the V2 /client/create API
+            clientType: 'CONFIDENTIAL',
+            grantTypes: ['AUTHORIZATION_CODE'],
+            responseTypes: ['CODE'],
+            redirectUris: [REDIRECT_URI]
+          )
         )
-      )
+      end
 
       client_id = read_field(client, :client_id, :clientId)
       client_secret = read_field(client, :client_secret, :clientSecret)
@@ -51,7 +55,9 @@ class AuthorizationCodeFlowTest < Minitest::Test
       ].join('&')
 
       puts '[smoke] Step 2: calling /auth/authorization'
-      authorization_response = api.authorization(parameters: authorization_parameters)
+      authorization_response = call_with_retry('/auth/authorization') do
+        api.authorization(parameters: authorization_parameters)
+      end
       assert_equal 'INTERACTION', read_field(authorization_response, :action)
 
       ticket = read_field(authorization_response, :ticket)
@@ -59,7 +65,9 @@ class AuthorizationCodeFlowTest < Minitest::Test
       puts '[smoke] Step 2 result: action=INTERACTION, ticket issued'
 
       puts '[smoke] Step 3: calling /auth/authorization/issue'
-      issue_response = api.authorization_issue(ticket: ticket, subject: SUBJECT)
+      issue_response = call_with_retry('/auth/authorization/issue') do
+        api.authorization_issue(ticket: ticket, subject: SUBJECT)
+      end
       assert_equal 'LOCATION', read_field(issue_response, :action)
 
       redirect_location = read_field(issue_response, :response_content, :responseContent)
@@ -78,11 +86,13 @@ class AuthorizationCodeFlowTest < Minitest::Test
       ].join('&')
 
       puts '[smoke] Step 4: calling /auth/token'
-      token_response = api.token(
-        parameters: token_parameters,
-        clientId: client_id.to_s,
-        clientSecret: client_secret
-      )
+      token_response = call_with_retry('/auth/token') do
+        api.token(
+          parameters: token_parameters,
+          clientId: client_id.to_s,
+          clientSecret: client_secret
+        )
+      end
       assert_equal 'OK', read_field(token_response, :action)
 
       access_token = read_field(token_response, :access_token, :accessToken)
@@ -90,7 +100,9 @@ class AuthorizationCodeFlowTest < Minitest::Test
       puts "[smoke] Step 4 result: accessTokenLength=#{access_token.length}"
 
       puts '[smoke] Step 5: calling /auth/introspection'
-      introspection_response = api.introspection(token: access_token)
+      introspection_response = call_with_retry('/auth/introspection') do
+        api.introspection(token: access_token)
+      end
       assert_equal 'OK', read_field(introspection_response, :action)
       assert_equal true, read_field(introspection_response, :usable),
                    'introspected access token must be usable'
@@ -105,7 +117,7 @@ class AuthorizationCodeFlowTest < Minitest::Test
         unless client_id.to_i.zero?
           puts "[smoke] Cleanup: deleting clientId=#{client_id}"
           begin
-            api.client_delete(client_id)
+            call_with_retry('/client/delete') { api.client_delete(client_id) }
             puts '[smoke] Cleanup result: client deleted'
           rescue StandardError => e
             # Fail the test when cleanup breaks, but never mask an earlier failure.
@@ -118,6 +130,28 @@ class AuthorizationCodeFlowTest < Minitest::Test
   end
 
   private
+
+  # Executes an Authlete API call, retrying transient errors (429 and 5xx)
+  # following https://www.authlete.com/kb/deployment/performance/ratelimit-best-practices/
+  # with exponential backoff (0.5 s, 1 s, 2 s) and a small random jitter.
+  # (Authlete::Exception does not expose response headers, so the
+  # Ratelimit-Reset header cannot be honored here.)
+  def call_with_retry(label)
+    attempt = 0
+    begin
+      yield
+    rescue Authlete::Exception => e
+      status = e.status_code.to_i
+      raise unless attempt < MAX_RETRIES && (status == 429 || status >= 500)
+
+      delay = (0.5 * (2**attempt)) + rand(0.0..0.25)
+      puts "[smoke] #{label} failed with HTTP #{status}; retrying in #{delay.round(2)}s " \
+           "(attempt #{attempt + 1}/#{MAX_RETRIES})"
+      sleep(delay)
+      attempt += 1
+      retry
+    end
+  end
 
   # Prefer the version-specific AUTHLETE_V2_* variables; fall back to the
   # plain AUTHLETE_* variables when they hold a V2 configuration.

--- a/ruby-v2/test/authorization_code_flow_test.rb
+++ b/ruby-v2/test/authorization_code_flow_test.rb
@@ -28,6 +28,7 @@ class AuthorizationCodeFlowTest < Minitest::Test
       client = api.client_create(
         Authlete::Model::Client.new(
           clientName: client_name,
+          developer: 'sdk-playground-developer', # required by the V2 /client/create API
           clientType: 'CONFIDENTIAL',
           grantTypes: ['AUTHORIZATION_CODE'],
           responseTypes: ['CODE'],

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -7,17 +7,21 @@ RUN apt-get update \
        curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Pre-install gems for faster container startup (run as root to write to system gem path)
-COPY Gemfile /tmp/Gemfile
+# Pre-install gems for faster container startup (run as root to write to system gem path).
+# The lockfile is included so the baked gems match it exactly and a later
+# `bundle install` does not need to write to the system gem path.
+COPY Gemfile Gemfile.lock /tmp/
 RUN cd /tmp && bundle install
 
-# Create a non-root user similar to other language samples
+# Create a non-root user similar to other language samples.
+# Permissions (not ownership) open up the gem path so the user keeps write
+# access even when the dev container remaps its UID (e.g. on CI runners).
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash --create-home $USERNAME \
-    && chown -R $USER_UID:$USER_GID /usr/local/bundle
+    && chmod -R a+rwX /usr/local/bundle
 
 USER $USERNAME
 WORKDIR /workspaces/ruby

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 ruby '>= 3.4'
 
 gem 'authlete_ruby_sdk', '1.0.0'
+gem 'minitest'  # for test/authorization_code_flow_test.rb (bundled gem since Ruby 3.1)

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
       faraday-retry (~> 2.4.0)
       sorbet-runtime (~> 0.6.12872)
     base64 (0.3.0)
+    drb (2.2.3)
     faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -20,9 +21,13 @@ GEM
       faraday (~> 2.0)
     json (2.19.3)
     logger (1.7.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     multipart-post (2.4.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
+    prism (1.9.0)
     sorbet-runtime (0.6.13133)
     uri (1.1.1)
 
@@ -32,6 +37,7 @@ PLATFORMS
 
 DEPENDENCIES
   authlete_ruby_sdk (= 1.0.0)
+  minitest
 
 RUBY VERSION
    ruby 3.4.8p72

--- a/ruby/test/authorization_code_flow_test.rb
+++ b/ruby/test/authorization_code_flow_test.rb
@@ -13,6 +13,8 @@ class AuthorizationCodeFlowTest < Minitest::Test
 
   REDIRECT_URI = 'https://sdk-playground.example.com/callback'
   SUBJECT = 'sdk-playground-user'
+  # Transient errors (429 and 5xx) are retried with exponential backoff.
+  MAX_RETRIES = 3
 
   def test_authorization_code_flow
     # Prefer the version-specific variables; fall back to the plain ones.
@@ -33,46 +35,52 @@ class AuthorizationCodeFlowTest < Minitest::Test
 
     begin
       puts "[1/6] Creating test client: #{client_name}"
-      created = sdk.clients.create(
-        service_id: service_id,
-        client: Components::ClientInput.new(
-          client_name: client_name,
-          client_type: Components::ClientType::CONFIDENTIAL,
-          grant_types: [Components::GrantType::AUTHORIZATION_CODE],
-          response_types: [Components::ResponseType::CODE],
-          redirect_uris: [REDIRECT_URI]
+      created = call_with_retry('/client/create') do
+        sdk.clients.create(
+          service_id: service_id,
+          client: Components::ClientInput.new(
+            client_name: client_name,
+            client_type: Components::ClientType::CONFIDENTIAL,
+            grant_types: [Components::GrantType::AUTHORIZATION_CODE],
+            response_types: [Components::ResponseType::CODE],
+            redirect_uris: [REDIRECT_URI]
+          )
         )
-      ).client
+      end.client
       refute_nil created, '/client/create returned no client'
       refute_nil created.client_id, 'created client has no client_id'
       refute_nil created.client_secret, 'created client has no client_secret'
       puts "      client_id=#{created.client_id}"
 
       puts '[2/6] Calling /auth/authorization'
-      authz = sdk.authorization.process_request(
-        service_id: service_id,
-        authorization_request: Components::AuthorizationRequest.new(
-          parameters: query_string(
-            'response_type' => 'code',
-            'client_id' => created.client_id.to_s,
-            'redirect_uri' => REDIRECT_URI,
-            'state' => state
+      authz = call_with_retry('/auth/authorization') do
+        sdk.authorization.process_request(
+          service_id: service_id,
+          authorization_request: Components::AuthorizationRequest.new(
+            parameters: query_string(
+              'response_type' => 'code',
+              'client_id' => created.client_id.to_s,
+              'redirect_uri' => REDIRECT_URI,
+              'state' => state
+            )
           )
         )
-      ).authorization_response
+      end.authorization_response
       refute_nil authz, '/auth/authorization returned no response body'
       assert_equal Components::AuthorizationResponseAction::INTERACTION, authz.action
       refute_empty authz.ticket.to_s, 'authorization ticket must be present'
       puts '      action=INTERACTION ticket issued'
 
       puts '[3/6] Calling /auth/authorization/issue'
-      issue = sdk.authorization.issue_response(
-        service_id: service_id,
-        authorization_issue_request: Components::AuthorizationIssueRequest.new(
-          ticket: authz.ticket,
-          subject: SUBJECT
+      issue = call_with_retry('/auth/authorization/issue') do
+        sdk.authorization.issue_response(
+          service_id: service_id,
+          authorization_issue_request: Components::AuthorizationIssueRequest.new(
+            ticket: authz.ticket,
+            subject: SUBJECT
+          )
         )
-      ).authorization_issue_response
+      end.authorization_issue_response
       refute_nil issue, '/auth/authorization/issue returned no response body'
       assert_equal Components::AuthorizationIssueResponseAction::LOCATION, issue.action
       assert_includes issue.response_content.to_s, 'code='
@@ -82,28 +90,32 @@ class AuthorizationCodeFlowTest < Minitest::Test
       puts '      action=LOCATION authorization code issued'
 
       puts '[4/6] Calling /auth/token'
-      token = sdk.tokens.process_request(
-        service_id: service_id,
-        token_request: Components::TokenRequest.new(
-          parameters: query_string(
-            'grant_type' => 'authorization_code',
-            'code' => code,
-            'redirect_uri' => REDIRECT_URI
-          ),
-          client_id: created.client_id.to_s,
-          client_secret: created.client_secret
+      token = call_with_retry('/auth/token') do
+        sdk.tokens.process_request(
+          service_id: service_id,
+          token_request: Components::TokenRequest.new(
+            parameters: query_string(
+              'grant_type' => 'authorization_code',
+              'code' => code,
+              'redirect_uri' => REDIRECT_URI
+            ),
+            client_id: created.client_id.to_s,
+            client_secret: created.client_secret
+          )
         )
-      ).token_response
+      end.token_response
       refute_nil token, '/auth/token returned no response body'
       assert_equal Components::TokenResponseAction::OK, token.action
       refute_empty token.access_token.to_s, 'access token must be present'
       puts '      action=OK access token issued'
 
       puts '[5/6] Calling /auth/introspection'
-      introspection = sdk.introspection.process_request(
-        service_id: service_id,
-        introspection_request: Components::IntrospectionRequest.new(token: token.access_token)
-      ).introspection_response
+      introspection = call_with_retry('/auth/introspection') do
+        sdk.introspection.process_request(
+          service_id: service_id,
+          introspection_request: Components::IntrospectionRequest.new(token: token.access_token)
+        )
+      end.introspection_response
       refute_nil introspection, '/auth/introspection returned no response body'
       assert_equal Components::IntrospectionResponseAction::OK, introspection.action
       assert_equal true, introspection.usable, 'introspected access token must be usable'
@@ -114,7 +126,9 @@ class AuthorizationCodeFlowTest < Minitest::Test
       if created&.client_id
         puts "[6/6] Deleting test client: #{created.client_id}"
         begin
-          sdk.clients.destroy(service_id: service_id, client_id: created.client_id.to_s)
+          call_with_retry('/client/delete') do
+            sdk.clients.destroy(service_id: service_id, client_id: created.client_id.to_s)
+          end
         rescue StandardError => e
           # Fail the test when cleanup breaks, but never mask an earlier failure.
           raise if flow_error.nil?
@@ -125,6 +139,34 @@ class AuthorizationCodeFlowTest < Minitest::Test
   end
 
   private
+
+  # Executes an Authlete API call, retrying transient errors (429 and 5xx)
+  # following https://www.authlete.com/kb/deployment/performance/ratelimit-best-practices/:
+  # honor the Ratelimit-Reset header when present, otherwise use exponential
+  # backoff (0.5 s, 1 s, 2 s) with a small random jitter.
+  def call_with_retry(label)
+    attempt = 0
+    begin
+      yield
+    rescue Authlete::Models::Errors::APIError => e
+      status = e.status_code.to_i
+      raise unless attempt < MAX_RETRIES && (status == 429 || status >= 500)
+
+      delay = retry_delay(attempt, e)
+      puts "      #{label} failed with HTTP #{status}; retrying in #{delay.round(2)}s " \
+           "(attempt #{attempt + 1}/#{MAX_RETRIES})"
+      sleep(delay)
+      attempt += 1
+      retry
+    end
+  end
+
+  def retry_delay(attempt, error)
+    reset_seconds = error.raw_response&.headers&.[]('ratelimit-reset').to_i
+    return [reset_seconds, 30].min if reset_seconds.positive?
+
+    (0.5 * (2**attempt)) + rand(0.0..0.25)
+  end
 
   def env_or_fallback(primary, fallback)
     value = ENV[primary].to_s

--- a/ruby/test/authorization_code_flow_test.rb
+++ b/ruby/test/authorization_code_flow_test.rb
@@ -13,17 +13,19 @@ class AuthorizationCodeFlowTest < Minitest::Test
 
   REDIRECT_URI = 'https://sdk-playground.example.com/callback'
   SUBJECT = 'sdk-playground-user'
-  REQUIRED_ENV = %w[AUTHLETE_BASE_URL AUTHLETE_SERVICE_APIKEY AUTHLETE_SERVICE_ACCESSTOKEN].freeze
 
   def test_authorization_code_flow
-    missing = REQUIRED_ENV.select { |key| ENV[key].to_s.empty? }
-    skip("Missing Authlete env vars: #{missing.join(', ')}") unless missing.empty?
+    # Prefer the version-specific variables; fall back to the plain ones.
+    base_url = env_or_fallback('AUTHLETE_V3_BASE_URL', 'AUTHLETE_BASE_URL')
+    service_id = env_or_fallback('AUTHLETE_V3_SERVICE_APIKEY', 'AUTHLETE_SERVICE_APIKEY')
+    access_token = env_or_fallback('AUTHLETE_V3_SERVICE_ACCESSTOKEN', 'AUTHLETE_SERVICE_ACCESSTOKEN')
 
-    service_id = ENV['AUTHLETE_SERVICE_APIKEY']
-    sdk = Authlete::Client.new(
-      bearer: ENV['AUTHLETE_SERVICE_ACCESSTOKEN'],
-      server_url: ENV['AUTHLETE_BASE_URL']
-    )
+    if [base_url, service_id, access_token].any? { |value| value.to_s.empty? }
+      skip('AUTHLETE_V3_BASE_URL, AUTHLETE_V3_SERVICE_APIKEY and AUTHLETE_V3_SERVICE_ACCESSTOKEN ' \
+           '(or plain AUTHLETE_* V3 credentials) are required')
+    end
+
+    sdk = Authlete::Client.new(bearer: access_token, server_url: base_url)
 
     client_name = "sdk-playground-smoke-#{SecureRandom.alphanumeric(8).downcase}"
     state = SecureRandom.alphanumeric(16)
@@ -123,6 +125,11 @@ class AuthorizationCodeFlowTest < Minitest::Test
   end
 
   private
+
+  def env_or_fallback(primary, fallback)
+    value = ENV[primary].to_s
+    value.empty? ? ENV[fallback].to_s : value
+  end
 
   def query_string(params)
     params.map { |key, value| "#{key}=#{CGI.escape(value)}" }.join('&')

--- a/ruby/test/authorization_code_flow_test.rb
+++ b/ruby/test/authorization_code_flow_test.rb
@@ -1,0 +1,134 @@
+require 'bundler/setup'
+require 'authlete_ruby_sdk'
+require 'cgi'
+require 'minitest/autorun'
+require 'securerandom'
+require 'uri'
+
+# Smoke test that runs a minimal OAuth 2.0 authorization code flow against
+# the Authlete V3 API: create client -> /auth/authorization ->
+# /auth/authorization/issue -> /auth/token -> /auth/introspection -> delete client.
+class AuthorizationCodeFlowTest < Minitest::Test
+  Components = Authlete::Models::Components
+
+  REDIRECT_URI = 'https://sdk-playground.example.com/callback'
+  SUBJECT = 'sdk-playground-user'
+  REQUIRED_ENV = %w[AUTHLETE_BASE_URL AUTHLETE_SERVICE_APIKEY AUTHLETE_SERVICE_ACCESSTOKEN].freeze
+
+  def test_authorization_code_flow
+    missing = REQUIRED_ENV.select { |key| ENV[key].to_s.empty? }
+    skip("Missing Authlete env vars: #{missing.join(', ')}") unless missing.empty?
+
+    service_id = ENV['AUTHLETE_SERVICE_APIKEY']
+    sdk = Authlete::Client.new(
+      bearer: ENV['AUTHLETE_SERVICE_ACCESSTOKEN'],
+      server_url: ENV['AUTHLETE_BASE_URL']
+    )
+
+    client_name = "sdk-playground-smoke-#{SecureRandom.alphanumeric(8).downcase}"
+    state = SecureRandom.alphanumeric(16)
+    created = nil
+
+    begin
+      puts "[1/6] Creating test client: #{client_name}"
+      created = sdk.clients.create(
+        service_id: service_id,
+        client: Components::ClientInput.new(
+          client_name: client_name,
+          client_type: Components::ClientType::CONFIDENTIAL,
+          grant_types: [Components::GrantType::AUTHORIZATION_CODE],
+          response_types: [Components::ResponseType::CODE],
+          redirect_uris: [REDIRECT_URI]
+        )
+      ).client
+      refute_nil created, '/client/create returned no client'
+      refute_nil created.client_id, 'created client has no client_id'
+      refute_nil created.client_secret, 'created client has no client_secret'
+      puts "      client_id=#{created.client_id}"
+
+      puts '[2/6] Calling /auth/authorization'
+      authz = sdk.authorization.process_request(
+        service_id: service_id,
+        authorization_request: Components::AuthorizationRequest.new(
+          parameters: query_string(
+            'response_type' => 'code',
+            'client_id' => created.client_id.to_s,
+            'redirect_uri' => REDIRECT_URI,
+            'state' => state
+          )
+        )
+      ).authorization_response
+      refute_nil authz, '/auth/authorization returned no response body'
+      assert_equal Components::AuthorizationResponseAction::INTERACTION, authz.action
+      refute_empty authz.ticket.to_s, 'authorization ticket must be present'
+      puts '      action=INTERACTION ticket issued'
+
+      puts '[3/6] Calling /auth/authorization/issue'
+      issue = sdk.authorization.issue_response(
+        service_id: service_id,
+        authorization_issue_request: Components::AuthorizationIssueRequest.new(
+          ticket: authz.ticket,
+          subject: SUBJECT
+        )
+      ).authorization_issue_response
+      refute_nil issue, '/auth/authorization/issue returned no response body'
+      assert_equal Components::AuthorizationIssueResponseAction::LOCATION, issue.action
+      assert_includes issue.response_content.to_s, 'code='
+      assert_equal state, query_value(issue.response_content, 'state')
+      code = query_value(issue.response_content, 'code')
+      refute_empty code.to_s, 'authorization code must be present'
+      puts '      action=LOCATION authorization code issued'
+
+      puts '[4/6] Calling /auth/token'
+      token = sdk.tokens.process_request(
+        service_id: service_id,
+        token_request: Components::TokenRequest.new(
+          parameters: query_string(
+            'grant_type' => 'authorization_code',
+            'code' => code,
+            'redirect_uri' => REDIRECT_URI
+          ),
+          client_id: created.client_id.to_s,
+          client_secret: created.client_secret
+        )
+      ).token_response
+      refute_nil token, '/auth/token returned no response body'
+      assert_equal Components::TokenResponseAction::OK, token.action
+      refute_empty token.access_token.to_s, 'access token must be present'
+      puts '      action=OK access token issued'
+
+      puts '[5/6] Calling /auth/introspection'
+      introspection = sdk.introspection.process_request(
+        service_id: service_id,
+        introspection_request: Components::IntrospectionRequest.new(token: token.access_token)
+      ).introspection_response
+      refute_nil introspection, '/auth/introspection returned no response body'
+      assert_equal Components::IntrospectionResponseAction::OK, introspection.action
+      assert_equal true, introspection.usable, 'introspected access token must be usable'
+      assert_equal SUBJECT, introspection.subject, 'access token must be bound to the test subject'
+      puts '      action=OK access token is valid'
+    ensure
+      flow_error = $! # exception currently propagating out of the begin block, if any
+      if created&.client_id
+        puts "[6/6] Deleting test client: #{created.client_id}"
+        begin
+          sdk.clients.destroy(service_id: service_id, client_id: created.client_id.to_s)
+        rescue StandardError => e
+          # Fail the test when cleanup breaks, but never mask an earlier failure.
+          raise if flow_error.nil?
+          puts "      WARNING: failed to delete test client: #{e.message}"
+        end
+      end
+    end
+  end
+
+  private
+
+  def query_string(params)
+    params.map { |key, value| "#{key}=#{CGI.escape(value)}" }.join('&')
+  end
+
+  def query_value(url, key)
+    CGI.parse(URI.parse(url.to_s).query.to_s).fetch(key, []).first
+  end
+end

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -4,10 +4,13 @@
   "description": "Sample console app that exercises the Authlete TypeScript SDK inside a Dev Container.",
   "main": "dist/main.js",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
     "dev": "ts-node --transpile-only src/main.ts",
-    "start": "node dist/main.js"
+    "start": "node dist/main.js",
+    "test": "node --require ts-node/register tests/authorization-code-flow.test.ts",
+    "typecheck": "tsc --noEmit",
+    "typecheck:build": "tsc -p tsconfig.build.json --noEmit"
   },
   "keywords": [
     "authlete",

--- a/typescript/tests/authorization-code-flow.test.ts
+++ b/typescript/tests/authorization-code-flow.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { randomBytes } from "node:crypto";
+import { Authlete } from "@authlete/typescript-sdk";
+import {
+  type AuthorizationIssueResponse,
+  type AuthorizationResponse,
+  type Client,
+  type IntrospectionResponse,
+  type TokenResponse,
+  AuthorizationIssueResponseAction,
+  AuthorizationResponseAction,
+  ClientType,
+  GrantType,
+  IntrospectionResponseAction,
+  ResponseType,
+  TokenResponseAction,
+} from "@authlete/typescript-sdk/models";
+
+const serviceId = process.env.AUTHLETE_SERVICE_APIKEY;
+const bearer = process.env.AUTHLETE_SERVICE_ACCESSTOKEN;
+const serverURL = process.env.AUTHLETE_BASE_URL;
+
+const missingEnvVars = [
+  ["AUTHLETE_BASE_URL", serverURL],
+  ["AUTHLETE_SERVICE_APIKEY", serviceId],
+  ["AUTHLETE_SERVICE_ACCESSTOKEN", bearer],
+].filter(([, value]) => !value).map(([name]) => name);
+
+function randomSuffix(length = 8): string {
+  return randomBytes(length).toString("hex").slice(0, length);
+}
+
+function requireEnv(value: string | undefined, name: string): string {
+  assert.ok(value, `${name} must be set when the test runs`);
+  return value;
+}
+
+function logStep(message: string, details?: unknown): void {
+  if (details === undefined) {
+    console.log(`[auth-code-smoke] ${message}`);
+    return;
+  }
+
+  console.log(`[auth-code-smoke] ${message}`, details);
+}
+
+function extractAuthorizationCode(issueResponse: AuthorizationIssueResponse, state: string): string {
+  const responseContent = issueResponse.responseContent;
+  assert.ok(responseContent, "authorization issue responseContent must not be empty");
+  assert.match(responseContent, /code=/, "authorization issue responseContent must include code");
+  assert.match(responseContent, new RegExp(`(?:[?&])state=${state}(?:[&#]|$)`), "authorization issue responseContent must include state");
+
+  const location = new URL(responseContent);
+  const code = location.searchParams.get("code");
+  const returnedState = location.searchParams.get("state");
+
+  assert.ok(code, "authorization code must be present in the redirect URI");
+  assert.equal(returnedState, state, "state must round-trip");
+
+  return code;
+}
+
+test("OAuth 2.0 authorization code flow smoke test", async (t) => {
+  if (missingEnvVars.length > 0) {
+    t.skip(`Missing Authlete env vars: ${missingEnvVars.join(", ")}`);
+    return;
+  }
+
+  const authlete = new Authlete({
+    bearer: requireEnv(bearer, "AUTHLETE_SERVICE_ACCESSTOKEN"),
+    serverURL: requireEnv(serverURL, "AUTHLETE_BASE_URL"),
+  });
+  const resolvedServiceId = requireEnv(serviceId, "AUTHLETE_SERVICE_APIKEY");
+
+  const clientName = `sdk-playground-smoke-${randomSuffix()}`;
+  const redirectUri = "https://sdk-playground.example.com/callback";
+  const state = `state-${randomSuffix(12)}`;
+
+  let createdClient: Client | undefined;
+  let flowError: unknown;
+
+  try {
+    logStep("Creating test client", { clientName });
+    createdClient = await authlete.client.create({
+      serviceId: resolvedServiceId,
+      client: {
+        clientName,
+        clientType: ClientType.Confidential,
+        grantTypes: [GrantType.AuthorizationCode],
+        responseTypes: [ResponseType.Code],
+        redirectUris: [redirectUri],
+      },
+    });
+
+    assert.ok(createdClient.clientId, "created client must include clientId");
+    assert.ok(createdClient.clientSecret, "created client must include clientSecret");
+
+    const clientId = String(createdClient.clientId);
+    const clientSecret = createdClient.clientSecret;
+
+    logStep("Calling /auth/authorization", { clientId, redirectUri, state });
+    const authorizationResponse: AuthorizationResponse = await authlete.authorization.processRequest({
+      serviceId: resolvedServiceId,
+      authorizationRequest: {
+        parameters: `response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&state=${encodeURIComponent(state)}`,
+      },
+    });
+
+    assert.equal(
+      authorizationResponse.action,
+      AuthorizationResponseAction.Interaction,
+      `expected authorization action ${AuthorizationResponseAction.Interaction}, got ${authorizationResponse.action}`,
+    );
+    assert.ok(authorizationResponse.ticket, "authorization response must include ticket");
+
+    logStep("Calling /auth/authorization/issue");
+    const authorizationIssueResponse: AuthorizationIssueResponse = await authlete.authorization.issue({
+      serviceId: resolvedServiceId,
+      authorizationIssueRequest: {
+        ticket: authorizationResponse.ticket,
+        subject: "sdk-playground-user",
+      },
+    });
+
+    assert.equal(
+      authorizationIssueResponse.action,
+      AuthorizationIssueResponseAction.Location,
+      `expected authorization issue action ${AuthorizationIssueResponseAction.Location}, got ${authorizationIssueResponse.action}`,
+    );
+
+    const code = extractAuthorizationCode(authorizationIssueResponse, state);
+    logStep("Extracted authorization code", { codeLength: code.length });
+
+    logStep("Calling /auth/token", { clientId });
+    const tokenResponse: TokenResponse = await authlete.token.process({
+      serviceId: resolvedServiceId,
+      tokenRequest: {
+        parameters: `grant_type=authorization_code&code=${encodeURIComponent(code)}&redirect_uri=${encodeURIComponent(redirectUri)}`,
+        clientId,
+        clientSecret,
+      },
+    });
+
+    assert.equal(
+      tokenResponse.action,
+      TokenResponseAction.Ok,
+      `expected token action ${TokenResponseAction.Ok}, got ${tokenResponse.action}`,
+    );
+    assert.ok(tokenResponse.accessToken, "token response must include accessToken");
+
+    logStep("Calling /auth/introspection");
+    const introspectionResponse: IntrospectionResponse = await authlete.introspection.process({
+      serviceId: resolvedServiceId,
+      introspectionRequest: {
+        token: tokenResponse.accessToken,
+      },
+    });
+
+    assert.equal(
+      introspectionResponse.action,
+      IntrospectionResponseAction.Ok,
+      `expected introspection action ${IntrospectionResponseAction.Ok}, got ${introspectionResponse.action}`,
+    );
+    assert.equal(introspectionResponse.usable, true, "introspection response must mark the token as usable");
+    assert.equal(introspectionResponse.subject, "sdk-playground-user", "introspection response must include the subject");
+  } catch (error) {
+    // Recorded instead of thrown so that cleanup always runs first.
+    flowError = error;
+  }
+
+  if (createdClient?.clientId) {
+    logStep("Deleting test client", { clientId: createdClient.clientId });
+    try {
+      await authlete.client.delete({
+        serviceId: resolvedServiceId,
+        clientId: String(createdClient.clientId),
+      });
+    } catch (error) {
+      if (flowError === undefined) {
+        flowError = error;
+      } else {
+        logStep("WARNING: failed to delete test client", error);
+      }
+    }
+  }
+
+  if (flowError !== undefined) {
+    throw flowError;
+  }
+});

--- a/typescript/tests/authorization-code-flow.test.ts
+++ b/typescript/tests/authorization-code-flow.test.ts
@@ -17,14 +17,15 @@ import {
   TokenResponseAction,
 } from "@authlete/typescript-sdk/models";
 
-const serviceId = process.env.AUTHLETE_SERVICE_APIKEY;
-const bearer = process.env.AUTHLETE_SERVICE_ACCESSTOKEN;
-const serverURL = process.env.AUTHLETE_BASE_URL;
+// Prefer the version-specific variables; fall back to the plain ones.
+const serviceId = process.env.AUTHLETE_V3_SERVICE_APIKEY || process.env.AUTHLETE_SERVICE_APIKEY;
+const bearer = process.env.AUTHLETE_V3_SERVICE_ACCESSTOKEN || process.env.AUTHLETE_SERVICE_ACCESSTOKEN;
+const serverURL = process.env.AUTHLETE_V3_BASE_URL || process.env.AUTHLETE_BASE_URL;
 
 const missingEnvVars = [
-  ["AUTHLETE_BASE_URL", serverURL],
-  ["AUTHLETE_SERVICE_APIKEY", serviceId],
-  ["AUTHLETE_SERVICE_ACCESSTOKEN", bearer],
+  ["AUTHLETE_V3_BASE_URL", serverURL],
+  ["AUTHLETE_V3_SERVICE_APIKEY", serviceId],
+  ["AUTHLETE_V3_SERVICE_ACCESSTOKEN", bearer],
 ].filter(([, value]) => !value).map(([name]) => name);
 
 function randomSuffix(length = 8): string {

--- a/typescript/tests/authorization-code-flow.test.ts
+++ b/typescript/tests/authorization-code-flow.test.ts
@@ -68,9 +68,22 @@ test("OAuth 2.0 authorization code flow smoke test", async (t) => {
     return;
   }
 
+  // Retry transient errors (the SDK defaults to 429/500/502/503/504 and
+  // honors the Retry-After header) with exponential backoff, following
+  // https://www.authlete.com/kb/deployment/performance/ratelimit-best-practices/
   const authlete = new Authlete({
     bearer: requireEnv(bearer, "AUTHLETE_SERVICE_ACCESSTOKEN"),
     serverURL: requireEnv(serverURL, "AUTHLETE_BASE_URL"),
+    retryConfig: {
+      strategy: "backoff",
+      backoff: {
+        initialInterval: 500,
+        maxInterval: 4000,
+        exponent: 2,
+        maxElapsedTime: 30000,
+      },
+      retryConnectionErrors: true,
+    },
   });
   const resolvedServiceId = requireEnv(serviceId, "AUTHLETE_SERVICE_APIKEY");
 

--- a/typescript/tsconfig.build.json
+++ b/typescript/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,15 +1,15 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": ".",
     "types": ["node"]
   },
-  "include": ["src"]
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- Add an OAuth 2.0 **authorization code flow smoke test** to every implemented language (java, java-jakarta, java-jaxrs, go, ruby, ruby-v2, typescript, php). Each test creates a disposable client, runs `/auth/authorization` → `/auth/authorization/issue` → `/auth/token` → `/auth/introspection` (asserting `usable` and the bound subject), and always deletes the client afterwards.
- Tests **skip gracefully** when `AUTHLETE_*` credentials are not configured, so a fresh checkout never fails.
- **Java tests cover both V2 and V3** in a single run via new optional `AUTHLETE_V2_*` / `AUTHLETE_V3_*` variables (falling back to plain `AUTHLETE_*`). V2-only SDKs (go, ruby-v2, php) skip when `AUTHLETE_API_VERSION=3`; V3-only SDKs (ruby, typescript) require V3 credentials.
- New **`Devcontainer smoke test` workflow** builds each language's Dev Container with `devcontainers/ci` — the same configuration GitHub Codespaces uses — and runs the smoke test inside it on every PR touching a language directory, so SDK auto-update PRs are verified automatically.
- `fix(go)`: pin `dlv` to v1.25.2 (`@latest` now resolves to delve 1.27, which requires go >= 1.25 and breaks the `golang:1.24.2` image build — caught by this very test).
- `ruby-v2`: pin minitest to 5.x (6.x depends on prism, which needs a compiler missing from the slim image).

## Required repository secrets

| Secret | Purpose |
|--------|---------|
| `AUTHLETE_V2_BASE_URL` / `AUTHLETE_V2_SERVICE_APIKEY` / `AUTHLETE_V2_SERVICE_APISECRET` | V2 flows (java*, go, ruby-v2, php) |
| `AUTHLETE_V3_BASE_URL` / `AUTHLETE_V3_SERVICE_APIKEY` / `AUTHLETE_V3_SERVICE_ACCESSTOKEN` | V3 flows (java*, ruby, typescript) |

⚠️ The V3 service access token must have **CREATE_CLIENT / DELETE_CLIENT** access rights, otherwise `/client/create` fails with `A457101`. Without secrets the workflow still verifies that all containers build and tests compile.

## Test plan

- [x] All 8 devcontainer images build locally via `docker compose`
- [x] All tests skip cleanly without credentials (verified inside the containers)
- [x] V3 flow reaches the Authlete server consistently across java×3 / ruby / typescript (currently blocked only by token access rights, `A457101`)
- [x] Configure `AUTHLETE_V2_*` / `AUTHLETE_V3_*` secrets and run the workflow end-to-end
- [ ] Verify the workflow triggers on an SDK auto-update PR